### PR TITLE
fix integer overflow in LZMAReader causing infinite loop

### DIFF
--- a/lzma-rust2/src/lzma_reader.rs
+++ b/lzma-rust2/src/lzma_reader.rs
@@ -199,12 +199,12 @@ impl<R: Read> LZMAReader<R> {
             return Ok(0);
         }
         let mut size = 0;
-        let mut len = buf.len() as u32;
-        let mut off = 0u32;
+        let mut len = buf.len() as u64;
+        let mut off = 0;
         while len > 0 {
             let mut copy_size_max = len;
-            if self.remaining_size <= u64::MAX / 2 && (self.remaining_size as u32) < len {
-                copy_size_max = self.remaining_size as u32;
+            if self.remaining_size <= u64::MAX / 2 && self.remaining_size < len {
+                copy_size_max = self.remaining_size;
             }
             self.lz.set_limit(copy_size_max as usize);
 
@@ -219,12 +219,12 @@ impl<R: Read> LZMAReader<R> {
                 }
             }
 
-            let copied_size = self.lz.flush(buf, off as _) as u32;
+            let copied_size = self.lz.flush(buf, off as _) as u64;
             off += copied_size;
             len -= copied_size;
             size += copied_size;
             if self.remaining_size <= u64::MAX / 2 {
-                self.remaining_size -= copied_size as u64;
+                self.remaining_size -= copied_size;
                 if self.remaining_size == 0 {
                     self.end_reached = true;
                 }


### PR DESCRIPTION
This fixes an overflow that was causing a deadlock and 100% thread usage for me. I suspect it happens whenever the reader exceeds `u32::MAX` and causes the overflow, but I have not checked the archives I am working on yet to see if I successfully processed one or not. With this fix I *was* able to process the archive I was stuck on.

I'm not sure if the cast to `u64` is what's best, or if maybe we should be using a safer cast? Let me know if you want me to make changes. 

This was a fun bug to find. I learned how to use `lldb` in VS Code even! Thanks for forking this library. It's very nice to have something capable of opening 7z files in Rust!