### PR TITLE
Update bzip2 to v0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.0 - UNRELEASED
+
+### Updated
+
+- Target optional dependency bzip2 v0.6.
+
 ## 0.14.1 - 2025-06-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ aes = { version = "0.8", optional = true }
 bit-set = "0.8"
 brotli = { version = ">= 7, < 9", default-features = false, optional = true, features = ["std"] }
 byteorder = "1"
-bzip2 = { version = "0.5", optional = true, features = ["libbz2-rs-sys"] }
+bzip2 = { version = "0.6", optional = true }
 cbc = { version = "0.1", optional = true }
 crc32fast = "1"
 flate2 = { version = "1", optional = true, features = ["zlib-rs"] }


### PR DESCRIPTION
The rust backend for bzip2 is not the default. There is no optional feature anymore to select it.