### PR TITLE
Implement multi threading for compressing and decompressing LZMA2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.17.0 - 2025-07-**
+
+### Added
+
+- Added muti threading support for LZMA2 file decompression.
+- Added missing documentation for the public API.
+
 ## 0.16.2 - 2025-07-16
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.17.0 - 2025-07-**
+## 0.17.0 - 2025-07-25
 
 ### Added
 
-- Added muti threading support for LZMA2 file decompression.
+- Added muti-threading support for LZMA2 compression & decompression.
+- Added `ArchiveReader::set_thread_count()` to set the thread count when decoding with multiple threads.
+  Only LZMA2 is supported right now. `ArchiveReader` will set the thread_count with the help of
+  `std::thread::available_parallelism` as default.
 - Added missing documentation for the public API.
+
+### Changed
+
+- Split `LZMA2Option` into `LZMAOptions` and `LZMA2Options` to better support multi-threading encoding for LZMA2.
+- Removed `EncoderOptions::Num` enum, which means encoders needs to be configured with their respected option struct.
 
 ## 0.16.2 - 2025-07-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "sevenz-rust2"
 readme = "README.md"
 repository = "https://github.com/hasenbanck/sevenz-rust"
 rust-version = "1.85"
-version = "0.16.2"
+version = "0.17.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -37,7 +37,7 @@ cbc = { version = "0.1", optional = true }
 crc32fast = "1"
 flate2 = { version = "1", optional = true, features = ["zlib-rs"] }
 getrandom = { version = "0.3", optional = true }
-lzma-rust2 = { version = "0.4", default-features = false, features = ["optimization"], path = "../lzma-rust2" }
+lzma-rust2 = { version = "0.5", default-features = false, features = ["optimization"] }
 ppmd-rust = { version = "1.2", optional = true }
 lz4_flex = { version = "0.11", optional = true }
 nt-time = { version = "0.11", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ cbc = { version = "0.1", optional = true }
 crc32fast = "1"
 flate2 = { version = "1", optional = true, features = ["zlib-rs"] }
 getrandom = { version = "0.3", optional = true }
-lzma-rust2 = { version = "0.4", default-features = false, features = ["optimization"] }
+lzma-rust2 = { version = "0.4", default-features = false, features = ["optimization"], path = "../lzma-rust2" }
 ppmd-rust = { version = "1.2", optional = true }
 lz4_flex = { version = "0.11", optional = true }
 nt-time = { version = "0.11", optional = true }

--- a/examples/block_decompress.rs
+++ b/examples/block_decompress.rs
@@ -10,7 +10,7 @@ fn main() {
     let my_file_name = "7zFormat.txt";
 
     for block_index in 0..block_count {
-        let forder_dec = BlockDecoder::new(block_index, &archive, &password, &mut file);
+        let forder_dec = BlockDecoder::new(1, block_index, &archive, &password, &mut file);
 
         if !forder_dec
             .entries()

--- a/examples/mt_decompress.rs
+++ b/examples/mt_decompress.rs
@@ -2,6 +2,13 @@ use std::{path::PathBuf, sync::Arc};
 
 use sevenz_rust2::{Archive, BlockDecoder, Password};
 
+// 0. The simplest way to use multi threading is to use simply the ArchiveReader.
+//    If the compression of the archive blocks supports multi threading, which is supported
+//    by this crate, then the ArchiveReader will use multiple threads to decode the blocks.
+//    We currently only support multi threading for decoding & encoding LZMA2.
+//    Brotli, LZ4 and ZSTD could we supported in the future, if there is ever demand to do so.
+//
+//    See `ArchiveReader::set_thread_count()` for more information.`
 fn main() {
     let time = std::time::Instant::now();
     let mut file = std::fs::File::open("examples/data/sample.7z").unwrap();
@@ -10,21 +17,27 @@ fn main() {
     let block_count = archive.blocks.len();
     if block_count <= 1 {
         println!("block count less than 1, use single thread");
-        //TODO use single thread
     }
     let archive = Arc::new(archive);
     let password = Arc::new(password);
 
     let mut threads = Vec::new();
+
+    // 1. We multi-thread by decompressing each block itself in parallel.
     for block_index in 0..block_count {
         let archive = archive.clone();
         let password = password.clone();
-        //TODO: use thread pool
+
         let handle = std::thread::spawn(move || {
             let mut source = std::fs::File::open("examples/data/sample.7z").unwrap();
-            let forder_dec = BlockDecoder::new(1, block_index, &archive, &password, &mut source);
+
+            // 2. For decoders that supports it, we can set the thread_count on the block decoder
+            //    so that it uses multiple threads to decode the block. Currently only LZMA2 is
+            //    supporting this. In this example we try to use 4 threads.
+            let block_decoder = BlockDecoder::new(4, block_index, &archive, &password, &mut source);
+
             let dest = PathBuf::from("examples/data/sample_mt/");
-            forder_dec
+            block_decoder
                 .for_each_entries(&mut |entry, reader| {
                     let dest = dest.join(entry.name());
                     sevenz_rust2::default_entry_extract_fn(entry, reader, &dest)?;
@@ -38,5 +51,9 @@ fn main() {
     threads
         .into_iter()
         .for_each(|handle| handle.join().unwrap());
-    println!("multi-thread decompress use time:{:?}", time.elapsed());
+
+    println!(
+        "multi-thread decompress took {:?} ms",
+        time.elapsed().as_millis()
+    );
 }

--- a/examples/mt_decompress.rs
+++ b/examples/mt_decompress.rs
@@ -22,7 +22,7 @@ fn main() {
         //TODO: use thread pool
         let handle = std::thread::spawn(move || {
             let mut source = std::fs::File::open("examples/data/sample.7z").unwrap();
-            let forder_dec = BlockDecoder::new(block_index, &archive, &password, &mut source);
+            let forder_dec = BlockDecoder::new(1, block_index, &archive, &password, &mut source);
             let dest = PathBuf::from("examples/data/sample_mt/");
             forder_dec
                 .for_each_entries(&mut |entry, reader| {

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -35,6 +35,10 @@ pub(crate) const K_ENCODED_HEADER: u8 = 0x17;
 pub(crate) const K_START_POS: u8 = 0x18;
 pub(crate) const K_DUMMY: u8 = 0x19;
 
+/// Represents a parsed 7z archive structure.
+///
+/// Contains metadata about the archive including files, compression blocks,
+/// and internal structure information necessary for decompression.
 #[derive(Debug, Default, Clone)]
 pub struct Archive {
     /// Offset from beginning of file + SIGNATURE_HEADER_SIZE to packed streams.
@@ -43,9 +47,13 @@ pub struct Archive {
     pub(crate) pack_crcs_defined: BitSet,
     pub(crate) pack_crcs: Vec<u64>,
     pub(crate) sub_streams_info: Option<SubStreamsInfo>,
+    /// Compression blocks in the archive.
     pub blocks: Vec<Block>,
+    /// File and directory entries in the archive.
     pub files: Vec<ArchiveEntry>,
+    /// Mapping between files, blocks, and pack streams.
     pub stream_map: StreamMap,
+    /// Whether this is a solid archive (better compression, slower random access).
     pub is_solid: bool,
 }
 
@@ -56,32 +64,58 @@ pub(crate) struct SubStreamsInfo {
     pub(crate) crcs: Vec<u64>,
 }
 
+/// Represents a single file or directory entry within a 7z archive.
+///
+/// Contains metadata about the entry including name, timestamps, attributes,
+/// and size information.
 #[derive(Debug, Default, Clone)]
 pub struct ArchiveEntry {
+    /// Name/path of the entry within the archive.
     pub name: String,
+    /// Whether this entry has associated data stream.
     pub has_stream: bool,
+    /// Whether this entry is a directory.
     pub is_directory: bool,
+    /// Whether this is an anti-item (used for deletion in updates).
     pub is_anti_item: bool,
+    /// Whether creation date is present.
     pub has_creation_date: bool,
+    /// Whether last modified date is present.
     pub has_last_modified_date: bool,
+    /// Whether access date is present.
     pub has_access_date: bool,
+    /// Creation date and time.
     pub creation_date: NtTime,
+    /// Last modified date and time.
     pub last_modified_date: NtTime,
+    /// Last access date and time.
     pub access_date: NtTime,
+    /// Whether Windows file attributes are present.
     pub has_windows_attributes: bool,
+    /// Windows file attributes.
     pub windows_attributes: u32,
+    /// Whether CRC is present.
     pub has_crc: bool,
+    /// CRC32 checksum of uncompressed data.
     pub crc: u64,
+    /// CRC32 checksum of compressed data.
     pub compressed_crc: u64,
+    /// Uncompressed size in bytes.
     pub size: u64,
+    /// Compressed size in bytes.
     pub compressed_size: u64,
 }
 
 impl ArchiveEntry {
+    /// Creates a new default archive entry.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Creates a new archive entry representing a file.
+    ///
+    /// # Arguments
+    /// * `entry_name` - The name/path of the file within the archive
     pub fn new_file(entry_name: &str) -> Self {
         Self {
             name: entry_name.to_string(),
@@ -91,6 +125,10 @@ impl ArchiveEntry {
         }
     }
 
+    /// Creates a new archive entry representing a directory.
+    ///
+    /// # Arguments
+    /// * `entry_name` - The name/path of the directory within the archive
     pub fn new_directory(entry_name: &str) -> Self {
         Self {
             name: entry_name.to_string(),
@@ -100,6 +138,14 @@ impl ArchiveEntry {
         }
     }
 
+    /// Creates a new archive entry from a filesystem path.
+    ///
+    /// Automatically extracts metadata like timestamps and attributes from the filesystem.
+    /// On Windows, backslashes in the entry name are converted to forward slashes.
+    ///
+    /// # Arguments
+    /// * `path` - The filesystem path to extract metadata from
+    /// * `entry_name` - The name/path to use for this entry within the archive
     pub fn from_path(path: impl AsRef<std::path::Path>, entry_name: String) -> Self {
         let path = path.as_ref();
         #[cfg(target_os = "windows")]
@@ -142,48 +188,62 @@ impl ArchiveEntry {
         entry
     }
 
+    /// Returns the name/path of this entry within the archive.
     pub fn name(&self) -> &str {
         self.name.as_ref()
     }
 
+    /// Returns whether this entry is a directory.
     pub fn is_directory(&self) -> bool {
         self.is_directory
     }
 
+    /// Returns whether this entry has an associated data stream.
     pub fn has_stream(&self) -> bool {
         self.has_stream
     }
 
+    /// Returns the creation date of this entry.
     pub fn creation_date(&self) -> NtTime {
         self.creation_date
     }
 
+    /// Returns the last modified date of this entry.
     pub fn last_modified_date(&self) -> NtTime {
         self.last_modified_date
     }
 
-    pub fn size(&self) -> u64 {
+    /// Returns the uncompressed size of this entry in bytes.
+    pub fn size(&self) -> u64{
         self.size
     }
 
+    /// Returns the Windows file attributes of this entry.
     pub fn windows_attributes(&self) -> u32 {
         self.windows_attributes
     }
 
+    /// Returns the last access date of this entry.
     pub fn access_date(&self) -> NtTime {
         self.access_date
     }
 
+    /// Returns whether this entry is an anti-item (used for deletion in updates).
     pub fn is_anti_item(&self) -> bool {
         self.is_anti_item
     }
 }
 
+/// Configuration for encoding methods when compressing data.
+///
+/// Combines an encoder method with optional encoder-specific options.
 #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 #[cfg(feature = "compress")]
 #[derive(Debug, Default)]
 pub struct EncoderConfiguration {
+    /// The encoder method to use.
     pub method: EncoderMethod,
+    /// Optional encoder-specific options.
     pub options: Option<EncoderOptions>,
 }
 
@@ -206,6 +266,10 @@ impl Clone for EncoderConfiguration {
 
 #[cfg(feature = "compress")]
 impl EncoderConfiguration {
+    /// Creates a new encoder configuration with the specified method.
+    ///
+    /// # Arguments
+    /// * `method` - The encoder method to use
     pub fn new(method: EncoderMethod) -> Self {
         Self {
             method,
@@ -213,6 +277,10 @@ impl EncoderConfiguration {
         }
     }
 
+    /// Adds encoder-specific options to this configuration.
+    ///
+    /// # Arguments
+    /// * `options` - The encoder options to apply
     pub fn with_options(mut self, options: EncoderOptions) -> Self {
         self.options = Some(options);
         self
@@ -224,53 +292,97 @@ impl EncoderConfiguration {
 pub struct EncoderMethod(&'static str, &'static [u8]);
 
 impl EncoderMethod {
+    /// Method ID for COPY (no compression).
     pub const ID_COPY: &'static [u8] = &[0x00];
+    /// Method ID for Delta filter.
     pub const ID_DELTA: &'static [u8] = &[0x03];
 
+    /// Method ID for LZMA compression.
     pub const ID_LZMA: &'static [u8] = &[0x03, 0x01, 0x01];
+    /// Method ID for BCJ x86 filter.
     pub const ID_BCJ_X86: &'static [u8] = &[0x03, 0x03, 0x01, 0x03];
+    /// Method ID for BCJ2 filter.
     pub const ID_BCJ2: &'static [u8] = &[0x03, 0x03, 0x01, 0x1B];
+    /// Method ID for BCJ PowerPC filter.
     pub const ID_BCJ_PPC: &'static [u8] = &[0x03, 0x03, 0x02, 0x05];
+    /// Method ID for BCJ IA64 filter.
     pub const ID_BCJ_IA64: &'static [u8] = &[0x03, 0x03, 0x04, 0x01];
+    /// Method ID for BCJ ARM filter.
     pub const ID_BCJ_ARM: &'static [u8] = &[0x03, 0x03, 0x05, 0x01];
+    /// Method ID for BCJ ARM64 filter.
     pub const ID_BCJ_ARM64: &'static [u8] = &[0xA];
+    /// Method ID for BCJ ARM Thumb filter.
     pub const ID_BCJ_ARM_THUMB: &'static [u8] = &[0x03, 0x03, 0x07, 0x01];
+    /// Method ID for BCJ SPARC filter.
     pub const ID_BCJ_SPARC: &'static [u8] = &[0x03, 0x03, 0x08, 0x05];
+    /// Method ID for PPMD compression.
     pub const ID_PPMD: &'static [u8] = &[0x03, 0x04, 0x01];
 
+    /// Method ID for LZMA2 compression.
     pub const ID_LZMA2: &'static [u8] = &[0x21];
+    /// Method ID for BZIP2 compression.
     pub const ID_BZIP2: &'static [u8] = &[0x04, 0x02, 0x02];
+    /// Method ID for Zstandard compression.
     pub const ID_ZSTD: &'static [u8] = &[0x04, 0xF7, 0x11, 0x01];
+    /// Method ID for Brotli compression.
     pub const ID_BROTLI: &'static [u8] = &[0x04, 0xF7, 0x11, 0x02];
+    /// Method ID for LZ4 compression.
     pub const ID_LZ4: &'static [u8] = &[0x04, 0xF7, 0x11, 0x04];
+    /// Method ID for LZS compression.
     pub const ID_LZS: &'static [u8] = &[0x04, 0xF7, 0x11, 0x05];
+    /// Method ID for Lizard compression.
     pub const ID_LIZARD: &'static [u8] = &[0x04, 0xF7, 0x11, 0x06];
+    /// Method ID for Deflate compression.
     pub const ID_DEFLATE: &'static [u8] = &[0x04, 0x01, 0x08];
+    /// Method ID for Deflate64 compression.
     pub const ID_DEFLATE64: &'static [u8] = &[0x04, 0x01, 0x09];
+    /// Method ID for AES256-SHA256 encryption.
     pub const ID_AES256SHA256: &'static [u8] = &[0x06, 0xF1, 0x07, 0x01];
 
+    /// COPY method (no compression).
     pub const COPY: Self = Self("COPY", Self::ID_COPY);
+    /// LZMA compression method.
     pub const LZMA: Self = Self("LZMA", Self::ID_LZMA);
+    /// LZMA2 compression method.
     pub const LZMA2: Self = Self("LZMA2", Self::ID_LZMA2);
+    /// PPMD compression method.
     pub const PPMD: Self = Self("PPMD", Self::ID_PPMD);
+    /// BZIP2 compression method.
     pub const BZIP2: Self = Self("BZIP2", Self::ID_BZIP2);
+    /// Zstandard compression method.
     pub const ZSTD: Self = Self("ZSTD", Self::ID_ZSTD);
+    /// Brotli compression method.
     pub const BROTLI: Self = Self("BROTLI", Self::ID_BROTLI);
+    /// LZ4 compression method.
     pub const LZ4: Self = Self("LZ4", Self::ID_LZ4);
+    /// LZS compression method.
     pub const LZS: Self = Self("LZS", Self::ID_LZS);
+    /// Lizard compression method.
     pub const LIZARD: Self = Self("LIZARD", Self::ID_LIZARD);
+    /// Deflate compression method.
     pub const DEFLATE: Self = Self("DEFLATE", Self::ID_DEFLATE);
+    /// Deflate64 compression method.
     pub const DEFLATE64: Self = Self("DEFLATE64", Self::ID_DEFLATE64);
+    /// AES256-SHA256 encryption method.
     pub const AES256SHA256: Self = Self("AES256SHA256", Self::ID_AES256SHA256);
 
+    /// BCJ x86 filter method.
     pub const BCJ_X86_FILTER: Self = Self("BCJ_X86", Self::ID_BCJ_X86);
+    /// BCJ PowerPC filter method.
     pub const BCJ_PPC_FILTER: Self = Self("BCJ_PPC", Self::ID_BCJ_PPC);
+    /// BCJ IA64 filter method.
     pub const BCJ_IA64_FILTER: Self = Self("BCJ_IA64", Self::ID_BCJ_IA64);
+    /// BCJ ARM filter method.
     pub const BCJ_ARM_FILTER: Self = Self("BCJ_ARM", Self::ID_BCJ_ARM);
+    /// BCJ ARM64 filter method.
     pub const BCJ_ARM64_FILTER: Self = Self("BCJ_ARM64", Self::ID_BCJ_ARM64);
+    /// BCJ ARM Thumb filter method.
     pub const BCJ_ARM_THUMB_FILTER: Self = Self("BCJ_ARM_THUMB", Self::ID_BCJ_ARM_THUMB);
+    /// BCJ SPARC filter method.
     pub const BCJ_SPARC_FILTER: Self = Self("BCJ_SPARC", Self::ID_BCJ_SPARC);
+    /// Delta filter method.
     pub const DELTA_FILTER: Self = Self("DELTA", Self::ID_DELTA);
+    /// BCJ2 filter method.
     pub const BCJ2_FILTER: Self = Self("BCJ2", Self::ID_BCJ2);
 
     const ENCODING_METHODS: &'static [&'static EncoderMethod] = &[
@@ -299,16 +411,22 @@ impl EncoderMethod {
     ];
 
     #[inline]
+    /// Returns the human-readable name of this encoder method.
     pub const fn name(&self) -> &'static str {
         self.0
     }
 
     #[inline]
+    /// Returns the binary ID of this encoder method.
     pub const fn id(&self) -> &'static [u8] {
         self.1
     }
 
     #[inline]
+    /// Finds an encoder method by its binary ID.
+    ///
+    /// # Arguments
+    /// * `id` - The binary method ID to search for
     pub fn by_id(id: &[u8]) -> Option<Self> {
         Self::ENCODING_METHODS
             .iter()
@@ -318,11 +436,17 @@ impl EncoderMethod {
     }
 }
 
+/// Mapping structure that correlates files, blocks, and pack streams within an archive.
+///
+/// This structure maintains the relationships between archive entries and their
+/// corresponding compression blocks and packed data streams.
 #[derive(Debug, Default, Clone)]
 pub struct StreamMap {
     pub(crate) block_first_pack_stream_index: Vec<usize>,
     pub(crate) pack_stream_offsets: Vec<u64>,
+    /// Index of first file for each block.
     pub block_first_file_index: Vec<usize>,
+    /// Block index for each file (None if file has no data).
     pub file_block_index: Vec<Option<usize>>,
 }
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -214,7 +214,7 @@ impl ArchiveEntry {
     }
 
     /// Returns the uncompressed size of this entry in bytes.
-    pub fn size(&self) -> u64{
+    pub fn size(&self) -> u64 {
         self.size
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -36,7 +36,7 @@ pub enum Decoder<R: Read> {
     BCJ(SimpleReader<R>),
     Delta(DeltaReader<R>),
     #[cfg(feature = "brotli")]
-    Brotli(BrotliDecoder<R>),
+    Brotli(Box<BrotliDecoder<R>>),
     #[cfg(feature = "bzip2")]
     BZip2(BzDecoder<R>),
     #[cfg(feature = "deflate")]
@@ -134,7 +134,7 @@ pub fn add_decoder<I: Read>(
         #[cfg(feature = "brotli")]
         EncoderMethod::ID_BROTLI => {
             let de = BrotliDecoder::new(input, 4096)?;
-            Ok(Decoder::Brotli(de))
+            Ok(Decoder::Brotli(Box::new(de)))
         }
         #[cfg(feature = "bzip2")]
         EncoderMethod::ID_BZIP2 => {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,4 @@
-use std::{io::Read, num::NonZeroU32};
+use std::io::Read;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "bzip2")]
@@ -119,12 +119,7 @@ pub fn add_decoder<I: Read>(
             let lz = if threads < 2 {
                 Decoder::LZMA2(Box::new(LZMA2Reader::new(input, dic_size, None)))
             } else {
-                Decoder::LZMA2MT(Box::new(LZMA2ReaderMT::new(
-                    input,
-                    dic_size,
-                    None,
-                    NonZeroU32::new(threads).unwrap(),
-                )))
+                Decoder::LZMA2MT(Box::new(LZMA2ReaderMT::new(input, dic_size, None, threads)))
             };
 
             Ok(lz)

--- a/src/encoder_options.rs
+++ b/src/encoder_options.rs
@@ -13,10 +13,15 @@ use crate::Password;
 #[cfg(feature = "bzip2")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bzip2")))]
 #[derive(Debug, Copy, Clone)]
+/// Options for BZIP2 compression.
 pub struct Bzip2Options(pub(crate) u32);
 
 #[cfg(feature = "bzip2")]
 impl Bzip2Options {
+    /// Creates BZIP2 options with the specified compression level.
+    ///
+    /// # Arguments
+    /// * `level` - Compression level (typically 1-9)
     pub const fn from_level(level: u32) -> Self {
         Self(level)
     }
@@ -37,6 +42,7 @@ const DEFAULT_SKIPPABLE_FRAME_SIZE: u32 = 128 * 1024;
 #[cfg(feature = "brotli")]
 #[cfg_attr(docsrs, doc(cfg(feature = "brotli")))]
 #[derive(Debug, Copy, Clone)]
+/// Options for Brotli compression.
 pub struct BrotliOptions {
     pub(crate) quality: u32,
     pub(crate) window: u32,
@@ -45,6 +51,11 @@ pub struct BrotliOptions {
 
 #[cfg(feature = "brotli")]
 impl BrotliOptions {
+    /// Creates Brotli options with the specified quality and window size.
+    ///
+    /// # Arguments
+    /// * `quality` - Compression quality (0-11, clamped to this range)
+    /// * `window` - Window size (10-24, clamped to this range)
     pub const fn from_quality_window(quality: u32, window: u32) -> Self {
         let quality = if quality > 11 { 11 } else { quality };
         let window = if window > 24 { 24 } else { window };
@@ -88,10 +99,15 @@ impl Default for BrotliOptions {
 #[cfg(feature = "compress")]
 #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 #[derive(Debug, Copy, Clone)]
+/// Options for Delta filter compression.
 pub struct DeltaOptions(pub(crate) u32);
 
 #[cfg(feature = "compress")]
 impl DeltaOptions {
+    /// Creates Delta options with the specified distance.
+    ///
+    /// # Arguments
+    /// * `distance` - Delta distance (1-256, clamped to this range, 0 becomes 1)
     pub const fn from_distance(distance: u32) -> Self {
         let distance = if distance == 0 {
             1
@@ -114,10 +130,15 @@ impl Default for DeltaOptions {
 #[cfg(feature = "deflate")]
 #[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
 #[derive(Debug, Copy, Clone)]
+/// Options for Deflate compression.
 pub struct DeflateOptions(pub(crate) u32);
 
 #[cfg(feature = "deflate")]
 impl DeflateOptions {
+    /// Creates Deflate options with the specified compression level.
+    ///
+    /// # Arguments
+    /// * `level` - Compression level (0-9, clamped to this range)
     pub const fn from_level(level: u32) -> Self {
         let level = if level > 9 { 9 } else { level };
         Self(level)
@@ -134,6 +155,7 @@ impl Default for DeflateOptions {
 #[cfg(feature = "lz4")]
 #[cfg_attr(docsrs, doc(cfg(feature = "lz4")))]
 #[derive(Debug, Copy, Clone, Default)]
+/// Options for LZ4 compression.
 pub struct LZ4Options {
     pub(crate) skippable_frame_size: u32,
 }
@@ -165,6 +187,7 @@ impl LZ4Options {
 #[cfg(feature = "ppmd")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ppmd")))]
 #[derive(Debug, Copy, Clone)]
+/// Options for PPMD compression.
 pub struct PPMDOptions {
     pub(crate) order: u32,
     pub(crate) memory_size: u32,
@@ -172,6 +195,10 @@ pub struct PPMDOptions {
 
 #[cfg(feature = "ppmd")]
 impl PPMDOptions {
+    /// Creates PPMD options with the specified compression level.
+    ///
+    /// # Arguments
+    /// * `level` - Compression level (0-9, clamped to this range)
     pub const fn from_level(level: u32) -> Self {
         const ORDERS: [u32; 10] = [3, 4, 4, 5, 5, 6, 8, 16, 24, 32];
 
@@ -182,6 +209,11 @@ impl PPMDOptions {
         Self { order, memory_size }
     }
 
+    /// Creates PPMD options with specific order and memory size parameters.
+    ///
+    /// # Arguments
+    /// * `order` - Model order (clamped to valid PPMD range)
+    /// * `memory_size` - Memory size in bytes (clamped to valid PPMD range)
     pub const fn from_order_memory_size(order: u32, memory_size: u32) -> Self {
         let order = if order > PPMD7_MAX_ORDER {
             PPMD7_MAX_ORDER
@@ -211,10 +243,15 @@ impl Default for PPMDOptions {
 #[cfg(feature = "zstd")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 #[derive(Debug, Copy, Clone)]
+/// Options for Zstandard compression.
 pub struct ZStandardOptions(pub(crate) u32);
 
 #[cfg(feature = "zstd")]
 impl ZStandardOptions {
+    /// Creates Zstandard options with the specified compression level.
+    ///
+    /// # Arguments
+    /// * `level` - Compression level (typically 1-22)
     pub const fn from_level(level: u32) -> Self {
         let level = if level > 22 { 22 } else { level };
         Self(level)
@@ -231,15 +268,26 @@ impl Default for ZStandardOptions {
 #[cfg_attr(docsrs, doc(cfg(feature = "aes256")))]
 #[cfg(feature = "aes256")]
 #[derive(Debug, Clone)]
+/// Options for AES256 encryption.
 pub struct AesEncoderOptions {
+    /// Password for encryption.
     pub password: Password,
+    /// Initialization vector for encryption.
     pub iv: [u8; 16],
+    /// Salt for key derivation.
     pub salt: [u8; 16],
+    /// Number of cycles power for key derivation.
     pub num_cycles_power: u8,
 }
 
 #[cfg(feature = "aes256")]
 impl AesEncoderOptions {
+    /// Creates new AES encoder options with the specified password.
+    ///
+    /// Generates random IV and salt values automatically.
+    ///
+    /// # Arguments
+    /// * `password` - Password for encryption
     pub fn new(password: Password) -> Self {
         let mut iv = [0; 16];
         getrandom::fill(&mut iv).expect("Can't generate IV");
@@ -271,35 +319,46 @@ impl AesEncoderOptions {
     }
 }
 
+/// Encoder-specific options for various compression and encryption methods.
 #[derive(Debug, Clone)]
 pub enum EncoderOptions {
+    /// Generic numeric option.
     Num(u32),
     #[cfg(feature = "compress")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
+    /// Delta filter options.
     Delta(DeltaOptions),
     #[cfg(feature = "compress")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
+    /// LZMA2 compression options.
     LZMA2(LZMA2Options),
     #[cfg(feature = "brotli")]
     #[cfg_attr(docsrs, doc(cfg(feature = "brotli")))]
+    /// Brotli compression options.
     BROTLI(BrotliOptions),
     #[cfg(feature = "bzip2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bzip2")))]
+    /// BZIP2 compression options.
     BZIP2(Bzip2Options),
     #[cfg(feature = "deflate")]
     #[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
+    /// Deflate compression options.
     DEFLATE(DeflateOptions),
     #[cfg(feature = "lz4")]
     #[cfg_attr(docsrs, doc(cfg(feature = "lz4")))]
+    /// LZ4 compression options.
     LZ4(LZ4Options),
     #[cfg(feature = "ppmd")]
     #[cfg_attr(docsrs, doc(cfg(feature = "ppmd")))]
+    /// PPMD compression options.
     PPMD(PPMDOptions),
     #[cfg(feature = "zstd")]
     #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
+    /// Zstandard compression options.
     ZSTD(ZStandardOptions),
     #[cfg(feature = "aes256")]
     #[cfg_attr(docsrs, doc(cfg(feature = "aes256")))]
+    /// AES256 encryption options.
     Aes(AesEncoderOptions),
 }
 
@@ -436,6 +495,9 @@ impl From<ZStandardOptions> for EncoderOptions {
 }
 
 impl EncoderOptions {
+    /// Gets the LZMA2 dictionary size for this encoder option.
+    ///
+    /// Returns the dictionary size if this is an LZMA2 option, or a default value otherwise.
     pub fn get_lzma2_dict_size(&self) -> u32 {
         match self {
             EncoderOptions::Num(n) => *n,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,24 +3,53 @@ use std::{borrow::Cow, fmt::Display};
 /// The error type of the crate.
 #[derive(Debug)]
 pub enum Error {
+    /// Invalid 7z signature found in file header.
     BadSignature([u8; 6]),
-    UnsupportedVersion { major: u8, minor: u8 },
+    /// Unsupported 7z format version.
+    UnsupportedVersion {
+        /// Major version number.
+        major: u8,
+        /// Minor version number.
+        minor: u8,
+    },
+    /// Checksum verification failed during decompression.
     ChecksumVerificationFailed,
+    /// Next header CRC mismatch.
     NextHeaderCrcMismatch,
+    /// IO error with optional context message.
     Io(std::io::Error, Cow<'static, str>),
+    /// Error opening file.
     FileOpen(std::io::Error, String),
+    /// Other error with description.
     Other(Cow<'static, str>),
+    /// Bad terminated streams info.
     BadTerminatedStreamsInfo(u8),
+    /// Bad terminated unpack info.
     BadTerminatedUnpackInfo,
+    /// Bad terminated pack info.
     BadTerminatedPackInfo(u8),
+    /// Bad terminated sub streams info.
     BadTerminatedSubStreamsInfo,
-    BadTerminatedheader(u8),
+    /// Bad terminated header.
+    BadTerminatedHeader(u8),
+    /// External compression method not supported.
     ExternalUnsupported,
+    /// Unsupported compression method.
     UnsupportedCompressionMethod(String),
-    MaxMemLimited { max_kb: usize, actaul_kb: usize },
+    /// Memory limit exceeded.
+    MaxMemLimited {
+        /// Maximum allowed memory in KB.
+        max_kb: usize,
+        /// Actual required memory in KB.
+        actaul_kb: usize,
+    },
+    /// Password required for encrypted archive.
     PasswordRequired,
+    /// Feature or operation not supported.
     Unsupported(Cow<'static, str>),
+    /// Possibly bad password for encrypted content.
     MaybeBadPassword(std::io::Error),
+    /// File not found.
     FileNotFound,
 }
 
@@ -32,26 +61,26 @@ impl From<std::io::Error> for Error {
 
 impl Error {
     #[inline]
-    pub fn other<S: Into<Cow<'static, str>>>(s: S) -> Self {
+    pub(crate) fn other<S: Into<Cow<'static, str>>>(s: S) -> Self {
         Self::Other(s.into())
     }
 
     #[inline]
-    pub fn unsupported<S: Into<Cow<'static, str>>>(s: S) -> Self {
+    pub(crate) fn unsupported<S: Into<Cow<'static, str>>>(s: S) -> Self {
         Self::Unsupported(s.into())
     }
 
     #[inline]
-    pub fn io(e: std::io::Error) -> Self {
+    pub(crate) fn io(e: std::io::Error) -> Self {
         Self::io_msg(e, "")
     }
 
     #[inline]
-    pub fn io_msg(e: std::io::Error, msg: impl Into<Cow<'static, str>>) -> Self {
+    pub(crate) fn io_msg(e: std::io::Error, msg: impl Into<Cow<'static, str>>) -> Self {
         Self::Io(e, msg.into())
     }
 
-    pub fn bad_password(e: std::io::Error, encryped: bool) -> Self {
+    pub(crate) fn bad_password(e: std::io::Error, encryped: bool) -> Self {
         if encryped {
             Self::MaybeBadPassword(e)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! | DELTA         | ✓             | ✓           |
 //! | BCJ2          | ✓             |             |
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(missing_docs)]
 
 #[cfg(target_arch = "wasm32")]
 extern crate wasm_bindgen;

--- a/src/time.rs
+++ b/src/time.rs
@@ -35,6 +35,7 @@ impl NtTime {
         Self(ft)
     }
 
+    /// Returns the current system time as an [`NtTime`].
     #[must_use]
     #[inline]
     pub fn now() -> Self {

--- a/src/writer/source_reader.rs
+++ b/src/writer/source_reader.rs
@@ -2,6 +2,10 @@ use std::io::Read;
 
 use crc32fast::Hasher;
 
+/// A wrapper around a reader that tracks read count and CRC32.
+///
+/// Used during compression to track how much data has been read and compute
+/// the CRC32 checksum of the data.
 pub struct SourceReader<R> {
     reader: R,
     size: usize,
@@ -32,6 +36,10 @@ impl<R: Read> Read for SourceReader<R> {
 }
 
 impl<R> SourceReader<R> {
+    /// Creates a new source reader wrapper.
+    ///
+    /// # Arguments
+    /// * `reader` - The underlying reader to wrap
     pub fn new(reader: R) -> Self {
         Self {
             reader,
@@ -41,10 +49,14 @@ impl<R> SourceReader<R> {
         }
     }
 
+    /// Returns the total number of bytes read so far.
     pub fn read_count(&self) -> usize {
         self.size
     }
 
+    /// Returns the CRC32 value of all data read.
+    ///
+    /// The CRC is only computed once all data has been read (when read returns 0).
     pub fn crc_value(&self) -> u32 {
         self.crc_value
     }

--- a/tests/decompression_tests.rs
+++ b/tests/decompression_tests.rs
@@ -240,7 +240,7 @@ fn test_bcj2() {
     let archive = Archive::read(&mut file, &Password::empty()).unwrap();
     for i in 0..archive.blocks.len() {
         let password = Password::empty();
-        let fd = BlockDecoder::new(i, &archive, &password, &mut file);
+        let fd = BlockDecoder::new(1, i, &archive, &password, &mut file);
         println!("entry_count:{}", fd.entry_count());
         fd.for_each_entries(&mut |entry, reader| {
             println!("{}=>{:?}", entry.has_stream, entry.name());


### PR DESCRIPTION
I also took the opportunity to add a lot of missing documentation.

Parallization for data inside a single block is currently only supported by LZMA2. Most compression methods don't support it.

The exceptions are: LZ4, ZSTD and Brotli. Those would require the implementation of a "multi threading layer" above them, since the crates that we use don't implement MT for us and for Brotli, the MT support is only bolted on by the 7zip ZSTD fork anyhow.

LZ4 and ZSTD are also already pretty fast themselves with just one core.

On my system the decompression speed was comparable with 7zip using multiple corse (around 2.1 GiB/s with 32 threads).