### PR TITLE
refactor: use ? consistently for error handling

### DIFF
--- a/src/codec/brotli.rs
+++ b/src/codec/brotli.rs
@@ -28,7 +28,7 @@ impl<R: Read> BrotliDecoder<R> {
         let header_read = match Read::read(&mut input, &mut header) {
             Ok(n) if n >= 4 => n,
             Ok(_) => return Err(Error::other("Input too short")),
-            Err(e) => return Err(Error::io(e)),
+            Err(e) => return Err(e.into()),
         };
 
         let magic_value = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);

--- a/src/codec/lz4.rs
+++ b/src/codec/lz4.rs
@@ -22,7 +22,7 @@ impl<R: Read> Lz4Decoder<R> {
         let header_read = match Read::read(&mut input, &mut header) {
             Ok(n) if n >= 4 => n,
             Ok(_) => return Err(Error::other("Input too short")),
-            Err(e) => return Err(Error::io(e)),
+            Err(e) => return Err(e.into()),
         };
 
         let magic_value = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::{io, io::Read};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 #[cfg(feature = "bzip2")]
@@ -152,7 +152,7 @@ pub fn add_decoder<I: Read>(
         }
         #[cfg(feature = "zstd")]
         EncoderMethod::ID_ZSTD => {
-            let zs = zstd::Decoder::new(input).map_err(Error::io)?;
+            let zs = zstd::Decoder::new(input)?;
             Ok(Decoder::ZSTD(zs))
         }
         EncoderMethod::ID_BCJ_X86 => {
@@ -272,7 +272,7 @@ fn get_lzma2_dic_size(coder: &Coder) -> Result<u32, Error> {
     Ok(size)
 }
 
-fn get_lzma_dic_size(coder: &Coder) -> Result<u32, Error> {
+fn get_lzma_dic_size(coder: &Coder) -> io::Result<u32> {
     let mut props = &coder.properties[1..5];
-    props.read_u32::<LittleEndian>().map_err(Error::io)
+    props.read_u32::<LittleEndian>()
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -229,9 +229,11 @@ pub(crate) fn add_encoder<W: Write>(
                 0 | 1 => Encoder::LZMA2(Some(LZMA2Writer::new(input, lzma2_options.options))),
                 _ => {
                     let threads = lzma2_options.threads;
-                    Encoder::LZMA2MT(Some(
-                        LZMA2WriterMT::new(input, lzma2_options.options, threads)?
-                    ))
+                    Encoder::LZMA2MT(Some(LZMA2WriterMT::new(
+                        input,
+                        lzma2_options.options,
+                        threads,
+                    )?))
                 }
             };
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -216,7 +216,7 @@ pub(crate) fn add_encoder<W: Write>(
                 Some(EncoderOptions::LZMA(options)) => options.clone(),
                 _ => LZMAOptions::default(),
             };
-            let lz = LZMAWriter::new_no_header(input, &options.0, false).map_err(Error::io)?;
+            let lz = LZMAWriter::new_no_header(input, &options.0, false)?;
             Ok(Encoder::LZMA(Some(lz)))
         }
         EncoderMethod::ID_LZMA2 => {
@@ -230,8 +230,7 @@ pub(crate) fn add_encoder<W: Write>(
                 _ => {
                     let threads = lzma2_options.threads;
                     Encoder::LZMA2MT(Some(
-                        LZMA2WriterMT::new(input, lzma2_options.options, threads)
-                            .map_err(Error::io)?,
+                        LZMA2WriterMT::new(input, lzma2_options.options, threads)?
                     ))
                 }
             };
@@ -308,7 +307,7 @@ pub(crate) fn add_encoder<W: Write>(
                 _ => ZStandardOptions::default(),
             };
 
-            let zstd_encoder = zstd::Encoder::new(input, options.0 as i32).map_err(Error::io)?;
+            let zstd_encoder = zstd::Encoder::new(input, options.0 as i32)?;
 
             Ok(Encoder::ZSTD(Some(zstd_encoder)))
         }

--- a/src/encryption/aes.rs
+++ b/src/encryption/aes.rs
@@ -334,7 +334,7 @@ mod tests {
         let options = AesEncoderOptions::new(password.clone());
         let mut enc = Aes256Sha256Encoder::new(writer, &options).unwrap();
         let original = include_bytes!("aes.rs");
-        let _ = enc.write_all(original).expect("encode data");
+        enc.write_all(original).expect("encode data");
         let _ = enc.write(&[]).unwrap();
 
         let mut encoded_data = &encoded[..];

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
 
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
-        Self::io(value)
+        Self::io_msg(value, "")
     }
 }
 
@@ -71,11 +71,6 @@ impl Error {
     }
 
     #[inline]
-    pub(crate) fn io(e: std::io::Error) -> Self {
-        Self::io_msg(e, "")
-    }
-
-    #[inline]
     pub(crate) fn io_msg(e: std::io::Error, msg: impl Into<Cow<'static, str>>) -> Self {
         Self::Io(e, msg.into())
     }
@@ -84,7 +79,7 @@ impl Error {
         if encryped {
             Self::MaybeBadPassword(e)
         } else {
-            Self::io(e)
+            Self::io_msg(e, "")
         }
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -902,7 +902,7 @@ impl Archive {
 
             coder.id_size = id_size as usize;
 
-            header.read(coder.decompression_method_id_mut())?;
+            header.read_exact(coder.decompression_method_id_mut())?;
             if is_simple {
                 coder.num_in_streams = 1;
                 coder.num_out_streams = 1;
@@ -915,7 +915,7 @@ impl Archive {
             if has_attributes {
                 let properties_size = read_usize(header, "properties size")?;
                 let mut props = vec![0u8; properties_size];
-                header.read(&mut props)?;
+                header.read_exact(&mut props)?;
                 coder.properties = props;
             }
             coders.push(coder);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,6 +2,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     fs::File,
+    io,
     io::{Read, Seek, SeekFrom},
     num::NonZeroUsize,
     rc::Rc,
@@ -193,12 +194,12 @@ impl Archive {
         reader.seek(SeekFrom::Start(0))?;
 
         let mut signature = [0; 6];
-        reader.read_exact(&mut signature).map_err(Error::io)?;
+        reader.read_exact(&mut signature)?;
         if signature != SEVEN_Z_SIGNATURE {
             return Err(Error::BadSignature(signature));
         }
         let mut versions = [0; 2];
-        reader.read_exact(&mut versions).map_err(Error::io)?;
+        reader.read_exact(&mut versions)?;
         let version_major = versions[0];
         let version_minor = versions[1];
         if version_major != 0 {
@@ -211,12 +212,10 @@ impl Archive {
         let start_header_crc = read_u32(reader)?;
 
         let header_valid = if start_header_crc == 0 {
-            let current_position = reader.stream_position().map_err(Error::io)?;
+            let current_position = reader.stream_position()?;
             let mut buf = [0; 20];
-            reader.read_exact(&mut buf).map_err(Error::io)?;
-            reader
-                .seek(SeekFrom::Start(current_position))
-                .map_err(Error::io)?;
+            reader.read_exact(&mut buf)?;
+            reader.seek(SeekFrom::Start(current_position))?;
             buf.iter().any(|a| *a != 0)
         } else {
             true
@@ -234,7 +233,7 @@ impl Archive {
         start_header_crc: u32,
     ) -> Result<StartHeader, Error> {
         let mut buf = [0; 20];
-        reader.read_exact(&mut buf).map_err(Error::io)?;
+        reader.read_exact(&mut buf)?;
         let crc32 = crc32fast::hash(&buf);
         if crc32 != start_header_crc {
             return Err(Error::ChecksumVerificationFailed);
@@ -280,9 +279,7 @@ impl Archive {
         let mut nid = read_u8(header)?;
         while nid != K_END {
             let property_size = read_usize(header, "propertySize")?;
-            header
-                .seek(SeekFrom::Current(property_size as i64))
-                .map_err(Error::io)?;
+            header.seek(SeekFrom::Current(property_size as i64))?;
             nid = read_u8(header)?;
         }
         Ok(())
@@ -295,10 +292,10 @@ impl Archive {
         thread_count: u32,
     ) -> Result<Self, Error> {
         let search_limit = 1024 * 1024;
-        let prev_data_size = reader.stream_position().map_err(Error::io)? + 20;
+        let prev_data_size = reader.stream_position()? + 20;
         let size = reader_len;
-        let min_pos = if reader.stream_position().map_err(Error::io)? + search_limit > size {
-            reader.stream_position().map_err(Error::io)?
+        let min_pos = if reader.stream_position()? + search_limit > size {
+            reader.stream_position()?
         } else {
             size - search_limit
         };
@@ -306,7 +303,7 @@ impl Archive {
         while pos > min_pos {
             pos -= 1;
 
-            reader.seek(SeekFrom::Start(pos)).map_err(Error::io)?;
+            reader.seek(SeekFrom::Start(pos))?;
             let nid = read_u8(reader)?;
             if nid == K_ENCODED_HEADER || nid == K_HEADER {
                 let start_header = StartHeader {
@@ -343,14 +340,12 @@ impl Archive {
 
         let next_header_size_int = start_header.next_header_size as usize;
 
-        reader
-            .seek(SeekFrom::Start(
-                SIGNATURE_HEADER_SIZE + start_header.next_header_offset,
-            ))
-            .map_err(Error::io)?;
+        reader.seek(SeekFrom::Start(
+            SIGNATURE_HEADER_SIZE + start_header.next_header_offset,
+        ))?;
 
         let mut buf = vec![0; next_header_size_int];
-        reader.read_exact(&mut buf).map_err(Error::io)?;
+        reader.read_exact(&mut buf)?;
         if verify_crc && crc32fast::hash(&buf) as u64 != start_header.next_header_crc {
             return Err(Error::NextHeaderCrcMismatch);
         }
@@ -411,9 +406,7 @@ impl Archive {
             return Err(Error::other("no packed streams, can't read encoded header"));
         }
 
-        reader
-            .seek(SeekFrom::Start(block_offset))
-            .map_err(Error::io)?;
+        reader.seek(SeekFrom::Start(block_offset))?;
         let coder_len = block.coders.len();
         let unpack_size = block.get_unpack_size() as usize;
         let pack_size = archive.pack_sizes[first_pack_stream_index] as usize;
@@ -520,7 +513,7 @@ impl Archive {
 
                     let size = assert_usize(size, "file names length")?;
                     // let mut names = vec![0u8; size - 1];
-                    // header.read_exact(&mut names).map_err(Error::io)?;
+                    // header.read_exact(&mut names)?;
                     let names_reader = NamesReader::new(header, size - 1);
 
                     let mut next_file = 0;
@@ -595,14 +588,10 @@ impl Archive {
                 }
                 K_START_POS => return Err(Error::other("kStartPos is unsupported, please report")),
                 K_DUMMY => {
-                    header
-                        .seek(SeekFrom::Current(size as i64))
-                        .map_err(Error::io)?;
+                    header.seek(SeekFrom::Current(size as i64))?;
                 }
                 _ => {
-                    header
-                        .seek(SeekFrom::Current(size as i64))
-                        .map_err(Error::io)?;
+                    header.seek(SeekFrom::Current(size as i64))?;
                 }
             };
         }
@@ -913,9 +902,7 @@ impl Archive {
 
             coder.id_size = id_size as usize;
 
-            header
-                .read(coder.decompression_method_id_mut())
-                .map_err(Error::io)?;
+            header.read(coder.decompression_method_id_mut())?;
             if is_simple {
                 coder.num_in_streams = 1;
                 coder.num_out_streams = 1;
@@ -928,7 +915,7 @@ impl Archive {
             if has_attributes {
                 let properties_size = read_usize(header, "properties size")?;
                 let mut props = vec![0u8; properties_size];
-                header.read(&mut props).map_err(Error::io)?;
+                header.read(&mut props)?;
                 coder.properties = props;
             }
             coders.push(coder);
@@ -1004,13 +991,13 @@ fn assert_usize(size: u64, field: &str) -> Result<usize, Error> {
 }
 
 #[inline]
-fn read_u64le<R: Read>(reader: &mut R) -> Result<u64, Error> {
+fn read_u64le<R: Read>(reader: &mut R) -> io::Result<u64> {
     let mut buf = [0; 8];
-    reader.read_exact(&mut buf).map_err(Error::io)?;
+    reader.read_exact(&mut buf)?;
     Ok(u64::from_le_bytes(buf))
 }
 
-fn read_u64<R: Read>(reader: &mut R) -> Result<u64, Error> {
+fn read_u64<R: Read>(reader: &mut R) -> io::Result<u64> {
     let first = read_u8(reader)? as u64;
     let mut mask = 0x80_u64;
     let mut value = 0;
@@ -1026,20 +1013,20 @@ fn read_u64<R: Read>(reader: &mut R) -> Result<u64, Error> {
 }
 
 #[inline(always)]
-fn read_u32<R: Read>(reader: &mut R) -> Result<u32, Error> {
+fn read_u32<R: Read>(reader: &mut R) -> io::Result<u32> {
     let mut buf = [0; 4];
-    reader.read_exact(&mut buf).map_err(Error::io)?;
+    reader.read_exact(&mut buf)?;
     Ok(u32::from_le_bytes(buf))
 }
 
 #[inline(always)]
-fn read_u8<R: Read>(reader: &mut R) -> Result<u8, Error> {
+fn read_u8<R: Read>(reader: &mut R) -> io::Result<u8> {
     let mut buf = [0];
-    reader.read_exact(&mut buf).map_err(Error::io)?;
+    reader.read_exact(&mut buf)?;
     Ok(buf[0])
 }
 
-fn read_all_or_bits<R: Read>(header: &mut R, size: usize) -> Result<BitSet, Error> {
+fn read_all_or_bits<R: Read>(header: &mut R, size: usize) -> io::Result<BitSet> {
     let all = read_u8(header)?;
     if all != 0 {
         let mut bits = BitSet::with_capacity(size);
@@ -1052,7 +1039,7 @@ fn read_all_or_bits<R: Read>(header: &mut R, size: usize) -> Result<BitSet, Erro
     }
 }
 
-fn read_bits<R: Read>(header: &mut R, size: usize) -> Result<BitSet, Error> {
+fn read_bits<R: Read>(header: &mut R, size: usize) -> io::Result<BitSet> {
     let mut bits = BitSet::with_capacity(size);
     let mut mask = 0u32;
     let mut cache = 0u32;
@@ -1097,10 +1084,10 @@ impl<R: Read> Iterator for NamesReader<'_, R> {
         self.cache.clear();
         let mut buf = [0; 2];
         while self.read_bytes < self.max_bytes {
-            let r = self.reader.read_exact(&mut buf).map_err(Error::io);
+            let r = self.reader.read_exact(&mut buf);
             self.read_bytes += 2;
             if let Err(e) = r {
-                return Some(Err(e));
+                return Some(Err(e.into()));
             }
             let u = u16::from_le_bytes(buf);
             if u == 0 {
@@ -1237,9 +1224,7 @@ impl<R: Read + Seek> ArchiveReader<R> {
             + archive.pack_pos
             + archive.stream_map.pack_stream_offsets[first_pack_stream_index];
 
-        source
-            .seek(SeekFrom::Start(block_offset))
-            .map_err(Error::io)?;
+        source.seek(SeekFrom::Start(block_offset))?;
         let pack_size = archive.pack_sizes[first_pack_stream_index] as usize;
 
         let mut decoder: Box<dyn Read> = Box::new(BoundedReader::new(source, pack_size));

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -24,7 +24,7 @@ pub fn compress<W: Write + Seek>(src: impl AsRef<Path>, dest: W) -> Result<W, Er
         src.as_ref().parent().unwrap_or(src.as_ref())
     };
     compress_path(src.as_ref(), parent, &mut archive_writer)?;
-    archive_writer.finish().map_err(Error::io)
+    Ok(archive_writer.finish()?)
 }
 
 /// Compresses a source file or directory to a destination writer with password encryption.
@@ -56,7 +56,7 @@ pub fn compress_encrypted<W: Write + Seek>(
         src.as_ref().parent().unwrap_or(src.as_ref())
     };
     compress_path(src.as_ref(), parent, &mut archive_writer)?;
-    archive_writer.finish().map_err(Error::io)
+    Ok(archive_writer.finish()?)
 }
 
 /// Compresses a source file or directory to a destination file path.
@@ -134,8 +134,8 @@ fn compress_path<W: Write + Seek, P: AsRef<Path>>(
             .read_dir()
             .map_err(|e| Error::io_msg(e, "error read dir"))?
         {
-            let dir = dir.map_err(Error::io)?;
-            let ftype = dir.file_type().map_err(Error::io)?;
+            let dir = dir?;
+            let ftype = dir.file_type()?;
             if ftype.is_dir() || ftype.is_file() {
                 compress_path(dir.path(), root, archive_writer)?;
             }
@@ -238,7 +238,7 @@ fn encode_path<W: Write + Seek>(
                 .to_string();
             zip.push_archive_entry(
                 ArchiveEntry::from_path(ele.as_path(), name),
-                Some(File::open(ele.as_path()).map_err(Error::io)?),
+                Some(File::open(ele.as_path())?),
             )?;
         }
         return Ok(());
@@ -255,7 +255,7 @@ fn encode_path<W: Write + Seek>(
         if size >= MAX_BLOCK_SIZE {
             zip.push_archive_entry(
                 ArchiveEntry::from_path(ele.as_path(), name),
-                Some(File::open(ele.as_path()).map_err(Error::io)?),
+                Some(File::open(ele.as_path())?),
             )?;
             continue;
         }

--- a/src/util/decompress.rs
+++ b/src/util/decompress.rs
@@ -136,12 +136,12 @@ fn decompress_impl<R: Read + Seek>(
 ) -> Result<(), Error> {
     use std::io::SeekFrom;
 
-    let pos = src_reader.stream_position().map_err(Error::io)?;
-    src_reader.seek(SeekFrom::Start(pos)).map_err(Error::io)?;
+    let pos = src_reader.stream_position()?;
+    src_reader.seek(SeekFrom::Start(pos))?;
     let mut seven = ArchiveReader::new(src_reader, password)?;
     let dest = PathBuf::from(dest.as_ref());
     if !dest.exists() {
-        std::fs::create_dir_all(&dest).map_err(Error::io)?;
+        std::fs::create_dir_all(&dest)?;
     }
     seven.for_each_entries(|entry, reader| {
         let dest_path = dest.join(entry.name());
@@ -169,7 +169,7 @@ pub fn default_entry_extract_fn(
     if entry.is_directory() {
         let dir = dest;
         if !dir.exists() {
-            std::fs::create_dir_all(dir).map_err(Error::io)?;
+            std::fs::create_dir_all(dir)?;
         }
     } else {
         let path = dest;
@@ -184,7 +184,7 @@ pub fn default_entry_extract_fn(
             .map_err(|e| Error::file_open(e, path.to_string_lossy().to_string()))?;
         if entry.size() > 0 {
             let mut writer = BufWriter::new(file);
-            std::io::copy(reader, &mut writer).map_err(Error::io)?;
+            std::io::copy(reader, &mut writer)?;
 
             let file = writer.get_mut();
             let file_times = FileTimes::new()

--- a/src/util/wasm.rs
+++ b/src/util/wasm.rs
@@ -30,7 +30,7 @@ pub fn decompress(src: Uint8Array, pwd: &str, f: &Function) -> Result<(), String
 
                 if entry.size() > 0 {
                     let mut writer = Vec::new();
-                    std::io::copy(reader, &mut writer).map_err(crate::Error::io)?;
+                    std::io::copy(reader, &mut writer)?;
                     let _ = f.call2(
                         &JsValue::NULL,
                         &JsValue::from(path),

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -101,9 +101,7 @@ impl ArchiveWriter<File> {
 impl<W: Write + Seek> ArchiveWriter<W> {
     /// Prepares writer to write a 7z archive to.
     pub fn new(mut writer: W) -> Result<Self> {
-        writer
-            .seek(std::io::SeekFrom::Start(SIGNATURE_HEADER_SIZE))
-            .map_err(Error::io)?;
+        writer.seek(std::io::SeekFrom::Start(SIGNATURE_HEADER_SIZE))?;
 
         Ok(Self {
             output: writer,


### PR DESCRIPTION
There was an inconsistent use of standard error handling conversion traits. This PR removes the inconsistency by replacing manual error mapping with `?`. Some function signatures have also been changed to retain the more precise `io::Error` type for as long as possible before converting to the less precise and more general `Error`.