### PR TITLE
chore: Replace `doc_cfg` with `doc_auto_cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,4 @@ name = "mt_decompress"
 required-features = ["default"]
 
 [package.metadata.docs.rs]
-features = ["aes256", "brotli", "bzip2", "compress", "deflate", "lz4", "util", "ppmd", "zstd"]
-rustdoc-args = ["--cfg", "docsrs"]
+all-features = true

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -237,7 +237,6 @@ impl ArchiveEntry {
 /// Configuration for encoding methods when compressing data.
 ///
 /// Combines an encoder method with optional encoder-specific options.
-#[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 #[cfg(feature = "compress")]
 #[derive(Debug, Default)]
 pub struct EncoderConfiguration {

--- a/src/encoder_options.rs
+++ b/src/encoder_options.rs
@@ -9,7 +9,6 @@ use crate::EncoderConfiguration;
 use crate::Password;
 
 #[cfg(feature = "compress")]
-#[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 #[derive(Debug, Clone)]
 /// Options for LZMA compression.
 pub struct LZMAOptions(pub(crate) lzma_rust2::LZMAOptions);
@@ -32,7 +31,6 @@ impl LZMAOptions {
 }
 
 #[cfg(feature = "compress")]
-#[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 #[derive(Debug, Clone)]
 /// Options for LZMA2 compression.
 pub struct LZMA2Options {
@@ -91,7 +89,6 @@ impl LZMA2Options {
 }
 
 #[cfg(feature = "bzip2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bzip2")))]
 #[derive(Debug, Copy, Clone)]
 /// Options for BZIP2 compression.
 pub struct Bzip2Options(pub(crate) u32);
@@ -120,7 +117,6 @@ const MINIMAL_SKIPPABLE_FRAME_SIZE: u32 = 64 * 1024;
 const DEFAULT_SKIPPABLE_FRAME_SIZE: u32 = 128 * 1024;
 
 #[cfg(feature = "brotli")]
-#[cfg_attr(docsrs, doc(cfg(feature = "brotli")))]
 #[derive(Debug, Copy, Clone)]
 /// Options for Brotli compression.
 pub struct BrotliOptions {
@@ -177,7 +173,6 @@ impl Default for BrotliOptions {
 }
 
 #[cfg(feature = "compress")]
-#[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 #[derive(Debug, Copy, Clone)]
 /// Options for Delta filter compression.
 pub struct DeltaOptions(pub(crate) u32);
@@ -208,7 +203,6 @@ impl Default for DeltaOptions {
 }
 
 #[cfg(feature = "deflate")]
-#[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
 #[derive(Debug, Copy, Clone)]
 /// Options for Deflate compression.
 pub struct DeflateOptions(pub(crate) u32);
@@ -233,7 +227,6 @@ impl Default for DeflateOptions {
 }
 
 #[cfg(feature = "lz4")]
-#[cfg_attr(docsrs, doc(cfg(feature = "lz4")))]
 #[derive(Debug, Copy, Clone, Default)]
 /// Options for LZ4 compression.
 pub struct LZ4Options {
@@ -265,7 +258,6 @@ impl LZ4Options {
 }
 
 #[cfg(feature = "ppmd")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ppmd")))]
 #[derive(Debug, Copy, Clone)]
 /// Options for PPMD compression.
 pub struct PPMDOptions {
@@ -321,7 +313,6 @@ impl Default for PPMDOptions {
 }
 
 #[cfg(feature = "zstd")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
 #[derive(Debug, Copy, Clone)]
 /// Options for Zstandard compression.
 pub struct ZStandardOptions(pub(crate) u32);
@@ -345,7 +336,6 @@ impl Default for ZStandardOptions {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "aes256")))]
 #[cfg(feature = "aes256")]
 #[derive(Debug, Clone)]
 /// Options for AES256 encryption.
@@ -403,43 +393,33 @@ impl AesEncoderOptions {
 #[derive(Debug, Clone)]
 pub enum EncoderOptions {
     #[cfg(feature = "compress")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
     /// Delta filter options.
     Delta(DeltaOptions),
     #[cfg(feature = "compress")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
     /// LZMA compression options.
     LZMA(LZMAOptions),
     #[cfg(feature = "compress")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
     /// LZMA2 compression options.
     LZMA2(LZMA2Options),
     #[cfg(feature = "brotli")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "brotli")))]
     /// Brotli compression options.
     BROTLI(BrotliOptions),
     #[cfg(feature = "bzip2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bzip2")))]
     /// BZIP2 compression options.
     BZIP2(Bzip2Options),
     #[cfg(feature = "deflate")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
     /// Deflate compression options.
     DEFLATE(DeflateOptions),
     #[cfg(feature = "lz4")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "lz4")))]
     /// LZ4 compression options.
     LZ4(LZ4Options),
     #[cfg(feature = "ppmd")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ppmd")))]
     /// PPMD compression options.
     PPMD(PPMDOptions),
     #[cfg(feature = "zstd")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "zstd")))]
     /// Zstandard compression options.
     ZSTD(ZStandardOptions),
     #[cfg(feature = "aes256")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "aes256")))]
     /// AES256 encryption options.
     Aes(AesEncoderOptions),
 }

--- a/src/encryption/aes.rs
+++ b/src/encryption/aes.rs
@@ -225,7 +225,6 @@ impl Cipher {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "aes256")))]
 #[cfg(feature = "compress")]
 pub(crate) struct Aes256Sha256Encoder<W> {
     output: W,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! | BCJ IA64      | ✓             | ✓           |
 //! | BCJ2          |               |             |
 //! | DELTA         | ✓             | ✓           |
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 
 #[cfg(target_arch = "wasm32")]
@@ -40,7 +40,6 @@ extern crate wasm_bindgen;
 #[cfg(feature = "compress")]
 mod encoder;
 /// Encoding options when compressing.
-#[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 #[cfg(feature = "compress")]
 pub mod encoder_options;
 mod encryption;

--- a/src/time.rs
+++ b/src/time.rs
@@ -121,7 +121,6 @@ impl TryFrom<std::time::SystemTime> for NtTime {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "nt-time")))]
 #[cfg(feature = "nt-time")]
 impl From<NtTime> for nt_time::FileTime {
     fn from(value: NtTime) -> Self {
@@ -129,7 +128,6 @@ impl From<NtTime> for nt_time::FileTime {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "nt-time")))]
 #[cfg(feature = "nt-time")]
 impl From<nt_time::FileTime> for NtTime {
     fn from(value: nt_time::FileTime) -> Self {

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -15,7 +15,6 @@ use crate::{ArchiveEntry, ArchiveWriter, EncoderMethod, Error, Password, writer:
 /// # Arguments
 /// * `src` - Path to the source file or directory to compress
 /// * `dest` - Writer that implements `Write + Seek` to write the compressed archive to
-#[cfg_attr(docsrs, doc(cfg(all(feature = "compress", feature = "util"))))]
 pub fn compress<W: Write + Seek>(src: impl AsRef<Path>, dest: W) -> Result<W, Error> {
     let mut archive_writer = ArchiveWriter::new(dest)?;
     let parent = if src.as_ref().is_dir() {
@@ -34,10 +33,6 @@ pub fn compress<W: Write + Seek>(src: impl AsRef<Path>, dest: W) -> Result<W, Er
 /// * `dest` - Writer that implements `Write + Seek` to write the compressed archive to
 /// * `password` - Password to encrypt the archive with
 #[cfg(feature = "aes256")]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(all(feature = "aes256", feature = "compress", feature = "util")))
-)]
 pub fn compress_encrypted<W: Write + Seek>(
     src: impl AsRef<Path>,
     dest: W,
@@ -66,7 +61,6 @@ pub fn compress_encrypted<W: Write + Seek>(
 /// # Arguments
 /// * `src` - Path to the source file or directory to compress
 /// * `dest` - Path where the compressed archive will be created
-#[cfg_attr(docsrs, doc(cfg(all(feature = "compress", feature = "util"))))]
 pub fn compress_to_path(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> Result<(), Error> {
     if let Some(path) = dest.as_ref().parent() {
         if !path.exists() {
@@ -91,10 +85,6 @@ pub fn compress_to_path(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> Result
 /// * `dest` - Path where the encrypted compressed archive will be created
 /// * `password` - Password to encrypt the archive with
 #[cfg(feature = "aes256")]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(all(feature = "aes256", feature = "compress", feature = "util")))
-)]
 pub fn compress_to_path_encrypted(
     src: impl AsRef<Path>,
     dest: impl AsRef<Path>,
@@ -161,7 +151,6 @@ impl<W: Write + Seek> ArchiveWriter<W> {
     /// # Arguments
     /// * `path` - Path to add to the compression
     /// * `filter` - Function that returns `true` for paths that should be included
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "compress", feature = "util"))))]
     pub fn push_source_path(
         &mut self,
         path: impl AsRef<Path>,
@@ -179,7 +168,6 @@ impl<W: Write + Seek> ArchiveWriter<W> {
     /// # Arguments
     /// * `path` - Path to add to the compression
     /// * `filter` - Function that returns `true` for paths that should be included
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "compress", feature = "util"))))]
     pub fn push_source_path_non_solid(
         &mut self,
         path: impl AsRef<Path>,

--- a/src/util/decompress.rs
+++ b/src/util/decompress.rs
@@ -17,7 +17,6 @@ use crate::{Error, Password, *};
 /// # Arguments
 /// * `src_path` - Path to the source archive file
 /// * `dest` - Path to the destination directory where files will be extracted
-#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
 pub fn decompress_file(src_path: impl AsRef<Path>, dest: impl AsRef<Path>) -> Result<(), Error> {
     let file = std::fs::File::open(src_path.as_ref())
         .map_err(|e| Error::file_open(e, src_path.as_ref().to_string_lossy().to_string()))?;
@@ -33,7 +32,6 @@ pub fn decompress_file(src_path: impl AsRef<Path>, dest: impl AsRef<Path>) -> Re
 /// * `src_path` - Path to the source archive file
 /// * `dest` - Path to the destination directory where files will be extracted
 /// * `extract_fn` - Custom function to handle each archive entry during extraction
-#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
 pub fn decompress_file_with_extract_fn(
     src_path: impl AsRef<Path>,
     dest: impl AsRef<Path>,
@@ -49,7 +47,6 @@ pub fn decompress_file_with_extract_fn(
 /// # Arguments
 /// * `src_reader` - Reader containing the archive data
 /// * `dest` - Path to the destination directory where files will be extracted
-#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
 pub fn decompress<R: Read + Seek>(src_reader: R, dest: impl AsRef<Path>) -> Result<(), Error> {
     decompress_with_extract_fn(src_reader, dest, default_entry_extract_fn)
 }
@@ -63,7 +60,6 @@ pub fn decompress<R: Read + Seek>(src_reader: R, dest: impl AsRef<Path>) -> Resu
 /// * `dest` - Path to the destination directory where files will be extracted
 /// * `extract_fn` - Custom function to handle each archive entry during extraction
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
 pub fn decompress_with_extract_fn<R: Read + Seek>(
     src_reader: R,
     dest: impl AsRef<Path>,
@@ -79,7 +75,6 @@ pub fn decompress_with_extract_fn<R: Read + Seek>(
 /// * `dest` - Path to the destination directory where files will be extracted
 /// * `password` - Password to decrypt the archive
 #[cfg(all(feature = "aes256", not(target_arch = "wasm32")))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "aes256", feature = "util"))))]
 pub fn decompress_file_with_password(
     src_path: impl AsRef<Path>,
     dest: impl AsRef<Path>,
@@ -97,7 +92,6 @@ pub fn decompress_file_with_password(
 /// * `dest` - Path to the destination directory where files will be extracted
 /// * `password` - Password to decrypt the archive
 #[cfg(all(feature = "aes256", not(target_arch = "wasm32")))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "aes256", feature = "util"))))]
 pub fn decompress_with_password<R: Read + Seek>(
     src_reader: R,
     dest: impl AsRef<Path>,
@@ -117,7 +111,6 @@ pub fn decompress_with_password<R: Read + Seek>(
 /// * `password` - Password to decrypt the archive
 /// * `extract_fn` - Custom function to handle each archive entry during extraction
 #[cfg(all(feature = "aes256", not(target_arch = "wasm32")))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "aes256", feature = "util"))))]
 pub fn decompress_with_extract_fn_and_password<R: Read + Seek>(
     src_reader: R,
     dest: impl AsRef<Path>,
@@ -158,7 +151,6 @@ fn decompress_impl<R: Read + Seek>(
 /// * `reader` - Reader for the entry's data
 /// * `dest` - Destination path for the entry
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "util")))]
 pub fn default_entry_extract_fn(
     entry: &ArchiveEntry,
     reader: &mut dyn Read,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -78,7 +78,6 @@ macro_rules! write_times {
 type Result<T> = std::result::Result<T, Error>;
 
 /// Writes a 7z archive file.
-#[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 pub struct ArchiveWriter<W: Write> {
     output: W,
     files: Vec<ArchiveEntry>,


### PR DESCRIPTION
- Replace [`doc_cfg`](https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html) with [`doc_auto_cfg`](https://doc.rust-lang.org/unstable-book/language-features/doc-auto-cfg.html). This will automatically generate `#[doc(cfg(...))]`.
- I think it would be useful to be able to see all API in this crate, so I enabled all features on [docs.rs](https://docs.rs/), and remove `--cfg docsrs` as it's passed automatically for all docs.rs builds.