### PR TITLE
refactor: remove unused branch on return value of stream_position()

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -81,9 +81,7 @@ impl<R: Read + Seek> Read for SeekableBoundedReader<R> {
         if self.cur >= self.bounds.1 {
             return Ok(0);
         }
-        if self.stream_position()? != self.cur {
-            self.inner.seek(SeekFrom::Start(self.cur))?;
-        }
+        self.inner.seek(SeekFrom::Start(self.cur))?;
         let buf2 = if buf.len() < (self.bounds.1 - self.cur) as usize {
             buf
         } else {


### PR DESCRIPTION
The default implementation of fn stream_position(), which is not overloaded, is

`self.seek(SeekFrom::Current(0))`

One can verify that the implementation of fn seek() will always return self.cur so this branch is never run.

Tracing the codepath of the `Seek` impl when we plug in `SeekFrom::Current(0)` into

https://github.com/hasenbanck/sevenz-rust2/blob/d053fa489bda4e0762d16568dd8cc62f0b80f090/src/reader.rs#L64-L77

the code reduces to `self.inner.seek(SeekFrom::Start(self.cur))`.

## Detailed argument
When we initialize `SeekableBoundedReader` `0 <= self.cur` holds and the only way `self.cur` can decrease is in `fn seek`. By the error check `self.cur` is not set to a new value if that value is smaller than 0. With induction we have that the early error return branch cannot occur when doing `self.stream_position()` because then `new_pos = self.cur >= 0`, which makes it equivalent to `self.inner.seek(SeekFrom::Start(self.cur))`.