### PR TITLE
Refactor seekable bounded reader and update documentation for BCJ2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Target lzma-rust2 v0.13.
+- Updated the documentation to include the BCJ2 codec again. It was never gone, only overlooked.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is a fork of the original, unmaintained sevenz-rust crate to continue the d
 | BCJ PPC       | ✓             | ✓           |
 | BCJ SPARC     | ✓             | ✓           |
 | BCJ IA64      | ✓             | ✓           |
-| BCJ2          |               |             |
+| BCJ2          | ✓             |             |
 | DELTA         | ✓             | ✓           |
 
 ### Usage

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -187,7 +187,6 @@ pub fn add_decoder<I: Read>(
             let de = BcjReader::new_riscv(input, 0);
             Ok(Decoder::BCJ(de))
         }
-        // TODO NHA: Add BCJ2 decoder
         EncoderMethod::ID_DELTA => {
             let d = if coder.properties.is_empty() {
                 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! | BCJ PPC       | ✓             | ✓           |
 //! | BCJ SPARC     | ✓             | ✓           |
 //! | BCJ IA64      | ✓             | ✓           |
-//! | BCJ2          |               |             |
+//! | BCJ2          | ✓             |             |
 //! | DELTA         | ✓             | ✓           |
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]


### PR DESCRIPTION
#66 drove me down a path to discover that the BCJ2 decoder is actually used and it's the reason for the always seeking, shared and bounded reader. The old code was highly confusing and didn't properly showed the need for the always seeking behavior before reading. Since BCJ2 uses multiple input streams, the underlying reader is shared between multiple instances of the seeking, bounded reader. I cleared that up and now it's shared nature should be much better explained.