### PR TITLE
Simplifying Read impl

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -125,19 +125,15 @@ impl<'a> Iterator for OrderedCoderIter<'a> {
     type Item = (usize, &'a Coder);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(i) = self.current {
-            self.current = if let Some(pair) = self.block.find_bind_pair_for_out_stream(i as usize)
-            {
-                Some(self.block.bind_pairs[pair].in_index)
-            } else {
-                None
-            };
-            self.block
-                .coders
-                .get(i as usize)
-                .map(|item| (i as usize, item))
+        let i = self.current?;
+        self.current = if let Some(pair) = self.block.find_bind_pair_for_out_stream(i as usize) {
+            Some(self.block.bind_pairs[pair].in_index)
         } else {
             None
-        }
+        };
+        self.block
+            .coders
+            .get(i as usize)
+            .map(|item| (i as usize, item))
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -42,11 +42,7 @@ impl<R: Read> Read for BoundedReader<R> {
             &mut buf[..self.remain]
         };
         let size = self.inner.read(buf2)?;
-        if self.remain < size {
-            self.remain = 0;
-        } else {
-            self.remain -= size;
-        }
+        self.remain -= size;
         Ok(size)
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -36,12 +36,8 @@ impl<R: Read> Read for BoundedReader<R> {
         if self.remain == 0 {
             return Ok(0);
         }
-        let buf2 = if buf.len() < self.remain {
-            buf
-        } else {
-            &mut buf[..self.remain]
-        };
-        let size = self.inner.read(buf2)?;
+        let bound = buf.len().min(self.remain);
+        let size = self.inner.read(&mut buf[..bound])?;
         self.remain -= size;
         Ok(size)
     }
@@ -91,12 +87,8 @@ impl<'a, R: Read + Seek> Read for SharedBoundedReader<'a, R> {
 
         inner.seek(SeekFrom::Start(self.cur))?;
 
-        let buf2 = if buf.len() < (self.bounds.1 - self.cur) as usize {
-            buf
-        } else {
-            &mut buf[..(self.bounds.1 - self.cur) as usize]
-        };
-        let size = inner.read(buf2)?;
+        let bound = buf.len().min((self.bounds.1 - self.cur) as usize);
+        let size = inner.read(&mut buf[..bound])?;
         self.cur += size as u64;
         Ok(size)
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -36,23 +36,18 @@ impl<R: Read> Read for BoundedReader<R> {
         if self.remain == 0 {
             return Ok(0);
         }
-        let remain = self.remain;
-        let buf2 = if buf.len() < remain {
+        let buf2 = if buf.len() < self.remain {
             buf
         } else {
-            &mut buf[..remain]
+            &mut buf[..self.remain]
         };
-        match self.inner.read(buf2) {
-            Ok(size) => {
-                if self.remain < size {
-                    self.remain = 0;
-                } else {
-                    self.remain -= size;
-                }
-                Ok(size)
-            }
-            Err(e) => Err(e),
+        let size = self.inner.read(buf2)?;
+        if self.remain < size {
+            self.remain = 0;
+        } else {
+            self.remain -= size;
         }
+        Ok(size)
     }
 }
 


### PR DESCRIPTION
The current code performs more conservative checks than necessary, since any well-behaved type that implements `Read` cannot return more bytes than the length of the slice it is reading into.

I removed an additional manual `?` implementation in a different spot because it seems simple to group together with a similar removal that was directly in my path.

In the same location I removed some manual implementations of the `min` function, the result I think is easier to read.