### PR TITLE
docs: Fix invalid link to `Password::empty`

### DIFF
--- a/src/encryption/password.rs
+++ b/src/encryption/password.rs
@@ -2,7 +2,7 @@ use crate::ByteWriter;
 
 /// A password used for password protected, encrypted files.
 ///
-/// Use `[Password::empty()]` to create an empty password when no
+/// Use [`Password::empty()`] to create an empty password when no
 /// password is used.
 ///
 /// You can convert strings easily into password using the Into/From traits:


### PR DESCRIPTION
I think this is intended to be a link to [`Password::empty()`](https://docs.rs/sevenz-rust2/0.18.0/sevenz_rust2/struct.Password.html#method.empty), but brackets and backticks are in the wrong place. So this will be displayed as `[Password::empty()]`, and will not work as a link.