### PR TITLE
Fix compatibility issue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,3 +111,104 @@ jobs:
         run: cargo clippy --workspace --all-features -- -D warnings
       - name: Check no lint warnings (no default features)
         run: cargo clippy --workspace --no-default-features -- -D warnings
+
+  windows-compatibility:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+      - name: Cache build artifacts
+        uses: Swatinem/rust-cache@v2.8.0
+
+      - name: Create solid archive
+        shell: bash
+        run: |
+          cargo run --release --example compress -- --solid -o solid.7z src/*.rs
+
+      - name: Create non-solid archive
+        shell: bash
+        run: |
+          cargo run --release --example compress -- -o non-solid.7z src/*.rs
+
+      - name: Test both archives with Explorer
+        shell: pwsh
+        run: |
+          $failed = $false
+          
+          function Get-AllArchiveItems {
+              param($folder, [string]$path = "")
+          
+              foreach ($item in $folder.Items()) {
+                  $itemPath = if ($path) { "$path\$($item.Name)" } else { $item.Name }
+                  Write-Host "    - $itemPath" -ForegroundColor Gray
+          
+                  if ($item.IsFolder) {
+                      Get-AllArchiveItems -folder $item.GetFolder -path $itemPath
+                  }
+              }
+          }
+          
+          function Test-NativeWindowsCompat {
+              param([string]$archivePath)
+          
+              Write-Host "`nTesting native Windows support for: $archivePath" -ForegroundColor Cyan
+          
+              if (-not (Test-Path $archivePath)) {
+                  Write-Error "File not found: $archivePath"
+                  return $false
+              }
+          
+              # Method 1: Test with Windows built-in tar command.
+              Write-Host "  Testing with Windows tar command..." -ForegroundColor Gray
+              try {
+                  $tarOutput = tar -tf $archivePath 2>&1
+                  if ($LASTEXITCODE -eq 0) {
+                      $fileCount = ($tarOutput | Measure-Object).Count
+                      Write-Host "  ✓ Windows tar can read archive ($fileCount files)" -ForegroundColor Green
+                  } else {
+                      Write-Error "  Windows tar cannot read the archive"
+                      return $false
+                  }
+              } catch {
+                  Write-Warning "  tar command failed: $_"
+              }
+          
+              # Method 2: Test with Shell.Application.
+              Write-Host "  Testing with Windows Shell..." -ForegroundColor Gray
+              $shell = New-Object -ComObject Shell.Application
+              $fullPath = (Resolve-Path $archivePath).Path
+              $archive = $shell.NameSpace($fullPath)
+          
+              if ($null -eq $archive) {
+                  Write-Error "  Windows Shell CANNOT open: $archivePath"
+                  return $false
+              } else {
+                  Write-Host "  ✓ Windows Shell can open (native): $archivePath" -ForegroundColor Green
+                  Write-Host "  Archive structure from Shell:" -ForegroundColor Gray
+                  Get-AllArchiveItems -folder $archive
+          
+                  return $true
+              }
+          }
+          
+          if (-not (Test-NativeWindowsCompat "solid.7z")) {
+              $failed = $true
+          }
+          
+          if (-not (Test-NativeWindowsCompat "non-solid.7z")) {
+              $failed = $true
+          }
+          
+          Write-Host "`n========================================" -ForegroundColor Yellow
+          if ($failed) {
+              Write-Error "One or more archives failed native Windows compatibility test"
+              exit 1
+          } else {
+              Write-Host "✓ All archives are compatible with native Windows support!" -ForegroundColor Green
+              exit 0
+          }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improved compatibility with third party utilities when creating 7z files (esp. Windows's Explorer and macOS's Finder).
 - Improve docs.rs feature compatibility @sorairolake (#56)
 
 ### Removed

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -1,13 +1,104 @@
-use std::time::Instant;
+use std::{env, fs::File, time::Instant};
+
+use sevenz_rust2::{ArchiveEntry, ArchiveReader, ArchiveWriter, NtTime, Password, SourceReader};
 
 fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        eprintln!(
+            "Usage: {} [--solid] [-o output.7z] <file1> [file2] ...",
+            args[0]
+        );
+        eprintln!("  --solid: Create a solid archive (all files compressed together)");
+        eprintln!("  -o <filename>: Specify output filename (default: output.7z)");
+        std::process::exit(1);
+    }
+
+    let mut solid = false;
+    let mut output_path = String::from("output.7z");
+    let mut file_paths = Vec::new();
+    let mut i = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--solid" => {
+                solid = true;
+                i += 1;
+            }
+            "-o" => {
+                if i + 1 >= args.len() {
+                    eprintln!("Error: -o option requires an output filename");
+                    std::process::exit(1);
+                }
+                output_path = args[i + 1].clone();
+                i += 2;
+            }
+            _ => {
+                file_paths.push(args[i].clone());
+                i += 1;
+            }
+        }
+    }
+
+    if file_paths.is_empty() {
+        eprintln!("Error: No files specified");
+        std::process::exit(1);
+    }
+
+    println!(
+        "Creating {} archive: {output_path}",
+        if solid { "solid" } else { "non-solid" }
+    );
+
     let now = Instant::now();
-    #[cfg(all(feature = "compress", feature = "aes256"))]
-    sevenz_rust2::compress_to_path_encrypted(
-        "examples/data/sample",
-        "examples/data/sample.7z",
-        "pass".into(),
-    )
-    .expect("compress ok");
-    println!("compress done : {:?}", now.elapsed());
+
+    let mut writer = ArchiveWriter::create(&output_path)
+        .unwrap_or_else(|error| panic!("Failed to create archive '{output_path}': {error}"));
+
+    if solid {
+        let mut entries = Vec::new();
+        let mut readers = Vec::new();
+
+        for file_path in &file_paths {
+            let file = File::open(file_path)
+                .unwrap_or_else(|error| panic!("Failed to open file '{file_path}': {error}"));
+
+            let modification_time = file.metadata().unwrap().modified().unwrap();
+
+            let mut entry = ArchiveEntry::new_file(file_path);
+            entry.has_last_modified_date = true;
+            entry.last_modified_date = NtTime::try_from(modification_time).unwrap();
+            entries.push(entry);
+            readers.push(SourceReader::new(file));
+
+            println!("Added file: {file_path}");
+        }
+
+        writer
+            .push_archive_entries(entries, readers)
+            .expect("Failed to add files to solid archive");
+    } else {
+        for file_path in &file_paths {
+            let file = File::open(file_path)
+                .unwrap_or_else(|error| panic!("Failed to open file '{file_path}': {error}"));
+
+            let entry = ArchiveEntry::new_file(file_path);
+            let reader = SourceReader::new(file);
+
+            writer
+                .push_archive_entry(entry, Some(reader))
+                .expect("Failed to add file to archive");
+
+            println!("Added file: {file_path}");
+        }
+    }
+
+    writer.finish().expect("Failed to finalize archive");
+
+    let _archive_reader = ArchiveReader::new(File::open(&output_path).unwrap(), Password::empty())
+        .unwrap_or_else(|error| panic!("Failed to open output file '{output_path}': {error}"));
+
+    println!("Archive created: {output_path}");
+    println!("Compress done: {:?}", now.elapsed());
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -130,7 +130,7 @@ impl<W: Write + Seek> ArchiveWriter<W> {
         self.encrypt_header = enabled;
     }
 
-    /// Adds an archive `entry` with data from `reader`.
+    /// Non-solid compression - Adds an archive `entry` with data from `reader`.
     ///
     /// # Example
     /// ```no_run
@@ -363,7 +363,7 @@ impl<W: Write + Seek> ArchiveWriter<W> {
             hhw.write_all(SEVEN_Z_SIGNATURE)?;
             //version
             hhw.write_u8(0)?;
-            hhw.write_u8(2)?;
+            hhw.write_u8(4)?;
             //placeholder for crc: index = 8
             hhw.write_u32(0)?;
 


### PR DESCRIPTION
This fixes the compatibility issue with both Windows Explorer and Apple Finder. Like 7zip, we always write out the CRCs in the substream information and never in the folder info.

This work well with solid, consolidate and mixed files.

I also made our reading logic more robust, since up until now, it always expected the CRC for the block to be in the folder info, which isn't even the case for files created by 7zip. We now properly also check the substream info, if there is a single CRC, which we could use. Multiple CRC would hint at multiple files in a solid compressed block, for which each CRC would be only for the compressed data of one of the files.

I also updated the version we write out to 4, since this is this format we are actually writing out.

I also made the compress example a bit more useful for us and added a compatibility test for windows with both solid and non-solid files.

Tested this changes with 7zip, Keka, Finder and Explorer.