### PR TITLE
Inline get_in_stream2 into callsite

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1335,11 +1335,11 @@ impl<R: Read + Seek> ArchiveReader<R> {
     where
         R: 'r,
     {
-        let index = block
+        if let Some(index) = block
             .packed_streams
             .iter()
-            .position(|&i| i == in_stream_index as u64);
-        if let Some(index) = index {
+            .position(|&i| i == in_stream_index as u64)
+        {
             return Ok(Box::new(sources[index].clone()));
         }
 


### PR DESCRIPTION
The separation between `get_in_stream` and `get_in_stream2` is quite awkward to read.
The functions have identical, not quite simple signatures, and do not seem to encapsulate any complexity. Schematically, they call each other as
```rust
fn get_in_stream(..) {
    // .. some checks

    get_in_stream2(..)
}
```

Inlining the call removes the question whether `get_in_stream2` is called from anywhere else, and makes it easier to understand `get_in_stream` itself, which is recursive.

Another thing that is quite confusing to read are the variable names, that seem semantically distinct but named the same, perhaps an artifact of when the function signature was copied and a forgotten rename.

The last change removes an intermediate variable binding which does not add a lot of clarity and given the multiple different uses of `index` in the function body, removes one that is both shadowed and used in a single place.