### PR TITLE
Fix wrong debug_assert and bug in push_source_path()

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,6 +135,16 @@ jobs:
         run: |
           cargo run --release --example compress -- -o non-solid.7z src/*.rs
 
+      - name: Create solid archive with single file
+        shell: bash
+        run: |
+          cargo run --release --example compress -- --solid -o solid-file.7z LICENSE
+
+      - name: Create non-solid archive with single file
+        shell: bash
+        run: |
+          cargo run --release --example compress -- -o non-solid-file.7z LICENSE
+
       - name: Test both archives with Explorer
         shell: pwsh
         run: |
@@ -201,6 +211,14 @@ jobs:
           }
           
           if (-not (Test-NativeWindowsCompat "non-solid.7z")) {
+              $failed = $true
+          }
+          
+          if (-not (Test-NativeWindowsCompat "solid-file.7z")) {
+              $failed = $true
+          }
+          
+          if (-not (Test-NativeWindowsCompat "non-solid-file.7z")) {
               $failed = $true
           }
           

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.1 - 2025-09-23
+
+### Fixed
+
+- Removed too strict debug_assert as reported in #81
+- Removed incompatibility issues when using the `ArchiveWriter::push_source_path()` with single files.
+  We now properly handle both cases were a file or a directory is given to the function.
+
 ## 0.19.0 - 2025-09-20
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "sevenz-rust2"
 readme = "README.md"
 repository = "https://github.com/hasenbanck/sevenz-rust"
 rust-version = "1.85"
-version = "0.19.0"
+version = "0.19.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/writer/unpack_info.rs
+++ b/src/writer/unpack_info.rs
@@ -104,8 +104,14 @@ impl UnpackInfo {
                 }
             } else if f.num_sub_unpack_streams == 1 {
                 // Single substream - write CRC here and not in the folder section.
-                debug_assert!(f.sub_stream_crcs.is_empty());
-                crcs_to_write.push(f.crc);
+                match f.sub_stream_crcs.first() {
+                    None => {
+                        crcs_to_write.push(f.crc);
+                    }
+                    Some(crc) => {
+                        crcs_to_write.push(*crc);
+                    }
+                };
             }
         }
 


### PR DESCRIPTION
Removed too strict debug_assert as reported in #81.

Removed incompatibility issues when using the `ArchiveWriter::push_source_path()` with single files. We now properly handle both cases were a file or a directory is given to the function.

Should fix #81