### PR TITLE
chore: Replace `doc_auto_cfg` with `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! | BCJ IA64      | ✓             | ✓           |
 //! | BCJ2          | ✓             |             |
 //! | DELTA         | ✓             | ✓           |
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
`doc_auto_cfg` was merged into `doc_cfg` in rust-lang/rust#138907.

When `docsrs` is enabled, the old `doc_auto_cfg` results in the following error on the latest nightlies:

```
error[E0557]: feature has been removed
  --> src/lib.rs:34:29
   |
34 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`
```

The new `doc_cfg` retains the automatic `cfg` generation that `doc_auto_cfg` used to provide.