### PR TITLE
Update ppmd-rust dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.X - 2025-11-XX
+
+### Updated
+
+- Target ppmd-rust v1. Since ppmd-rust is stable and has a major version, we will target it directly to reduce
+  maintenance burden.
+
 ## 0.19.2 - 2025-10-29
 
 ### Updated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ crc32fast = "1"
 flate2 = { version = "1", optional = true, features = ["zlib-rs"] }
 getrandom = { version = "0.3", optional = true }
 lzma-rust2 = { version = "0.15", default-features = false, features = ["std", "optimization"] }
-ppmd-rust = { version = "1.2", optional = true }
+ppmd-rust = { version = "1", optional = true }
 lz4_flex = { version = "0.11", optional = true }
 nt-time = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }


### PR DESCRIPTION
Target ppmd-rust v1. Since ppmd-rust is stable and has a major version, we will target it directly to reduce maintenance burden.