### PR TITLE
Fix write_file_anti_items: K_ANTI property was not written for anti-item-only archives

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -544,8 +544,8 @@ impl<W: Write + Seek> ArchiveWriter<W> {
         for entry in self.files.iter() {
             if !entry.has_stream {
                 let is_anti = entry.is_anti_item();
-                has_anti |= !is_anti;
-                if !is_anti {
+                has_anti |= is_anti;
+                if is_anti {
                     bitset.insert(counter);
                 }
                 counter += 1;

--- a/tests/compress_tests.rs
+++ b/tests/compress_tests.rs
@@ -404,6 +404,27 @@ fn compress_with_zstd_algorithm() {
     test_compression_method(&[EncoderMethod::ZSTD.into()]);
 }
 
+#[cfg(all(feature = "compress", feature = "util"))]
+#[test]
+fn anti_item_roundtrip() {
+    use std::io::Cursor;
+
+    let mut bytes = Vec::new();
+    {
+        let mut writer = ArchiveWriter::new(Cursor::new(&mut bytes)).unwrap();
+        let mut entry = ArchiveEntry::new_file("deleted.txt");
+        entry.is_anti_item = true;
+        writer.push_archive_entry::<&[u8]>(entry, None).unwrap();
+        writer.finish().unwrap();
+    }
+
+    let reader = ArchiveReader::new(Cursor::new(bytes.as_slice()), Password::empty()).unwrap();
+    assert_eq!(reader.archive().files.len(), 1);
+    let entry = &reader.archive().files[0];
+    assert_eq!(entry.name(), "deleted.txt");
+    assert!(entry.is_anti_item(), "entry should be an anti-item");
+}
+
 #[cfg(all(feature = "compress", feature = "aes256"))]
 #[test]
 fn encrypted_file_header_requires_password_to_read() {

--- a/tests/decompression_tests.rs
+++ b/tests/decompression_tests.rs
@@ -302,3 +302,41 @@ fn test_get_file_by_path() {
         assert_eq!(&data0, &data1);
     }
 }
+
+#[cfg(all(feature = "compress", feature = "util"))]
+#[test]
+fn anti_item_deletes_file_on_extract() {
+    use sevenz_rust2::{decompress_with_extract_fn_and_password, ArchiveEntry, ArchiveWriter};
+    use std::io::Cursor;
+
+    let temp_dir = tempdir().unwrap();
+    let target = temp_dir.path().join("to_delete.txt");
+    std::fs::write(&target, "will be deleted").unwrap();
+    assert!(target.exists());
+
+    let mut bytes = Vec::new();
+    {
+        let mut writer = ArchiveWriter::new(Cursor::new(&mut bytes)).unwrap();
+        let mut entry = ArchiveEntry::new_file("to_delete.txt");
+        entry.is_anti_item = true;
+        writer.push_archive_entry::<&[u8]>(entry, None).unwrap();
+        writer.finish().unwrap();
+    }
+
+    let dest = temp_dir.path().to_path_buf();
+    decompress_with_extract_fn_and_password(
+        Cursor::new(bytes.as_slice()),
+        &dest,
+        Password::empty(),
+        |entry, reader, dest_path| {
+            if entry.is_anti_item() {
+                std::fs::remove_file(dest_path).ok();
+                return Ok(true);
+            }
+            sevenz_rust2::default_entry_extract_fn(entry, reader, dest_path)
+        },
+    )
+    .unwrap();
+
+    assert!(!target.exists(), "anti-item should have been deleted");
+}


### PR DESCRIPTION
This fix was written entirely by Claude AI. I verified it works in my workflow using 7-zip, but I did not review the tests too deeply. Please have a look at them.

## What's broken

`write_file_anti_items` had inverted conditions — it set `has_anti = true` and populated the bitset when an entry was *not* an anti-item, and did nothing when it was. The result: archives containing only anti-items (no regular empty files) would never emit the `K_ANTI` property block at all, so entries appeared as ordinary 0-byte stubs on extraction instead of deletion markers.

## How I found it

I was using anti-items in a delta archive workflow and noticed that `7zz l -slt` showed no `Anti = +` property on any entries, and `7zz x` left the 0-byte files on disk instead of removing them.

## Verification

After the fix, `7zz l -slt` correctly shows `Anti = +` on anti-item entries, and `7zz x -y` deletes the corresponding files on extraction as expected per the 7z specification.

## Environment

```
% uname -a 
Darwin [hostname] 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:54:55 PST 2026; root:xnu-12377.91.3~2/RELEASE_ARM64_T8132 arm64
% 7zz -ver
7-Zip (z) 26.00 (arm64) : Copyright (c) 1999-2026 Igor Pavlov : 2026-02-12
 64-bit arm_v:8.5-A locale=UTF-8 Threads:10 OPEN_MAX:256, ASM
 ```