### PR TITLE
feat: push_packed_entry for non-solid pack-stream copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `ArchiveWriter::push_packed_entry` — write already-compressed pack bytes and folder
+  metadata without re-encoding (enables non-solid archive update / pack-stream copy).
+- Public accessors on `Block` / `Coder` for pack-copy clients:
+  `num_unpack_sub_streams`, `packed_streams_count`, `unpack_sizes`, `properties`,
+  `num_in_streams`, `num_out_streams`.
+
 ## 0.21.3 - 2026-07-05
 
 ### Changed

--- a/src/block.rs
+++ b/src/block.rs
@@ -68,6 +68,21 @@ impl Block {
     pub fn ordered_coder_iter(&self) -> OrderedCoderIter<'_> {
         OrderedCoderIter::new(self)
     }
+
+    /// Number of unpack sub-streams in this block (>1 means solid multi-file block).
+    pub fn num_unpack_sub_streams(&self) -> usize {
+        self.num_unpack_sub_streams
+    }
+
+    /// Number of packed input streams this block consumes from the pack region.
+    pub fn packed_streams_count(&self) -> usize {
+        self.packed_streams.len()
+    }
+
+    /// Per-coder unpack sizes (folder `CodersUnpackSize` values).
+    pub fn unpack_sizes(&self) -> &[u64] {
+        &self.unpack_sizes
+    }
 }
 
 /// Represents a single coder within a compression block.
@@ -90,6 +105,24 @@ impl Coder {
     /// method used by this coder.
     pub fn encoder_method_id(&self) -> &[u8] {
         &self.encoder_method_id[0..self.id_size]
+    }
+
+    /// Returns the coder property bytes stored in the archive header.
+    ///
+    /// Used by pack-stream copy paths that re-emit the same folder metadata without
+    /// re-encoding.
+    pub fn properties(&self) -> &[u8] {
+        &self.properties
+    }
+
+    /// Number of input streams this coder consumes.
+    pub fn num_in_streams(&self) -> u64 {
+        self.num_in_streams
+    }
+
+    /// Number of output streams this coder produces.
+    pub fn num_out_streams(&self) -> u64 {
+        self.num_out_streams
     }
 
     pub(crate) fn decompression_method_id_mut(&mut self) -> &mut [u8] {

--- a/src/util/compress.rs
+++ b/src/util/compress.rs
@@ -8,7 +8,9 @@ use std::{
 
 #[cfg(feature = "aes256")]
 use crate::encoder_options::AesEncoderOptions;
-use crate::{ArchiveEntry, ArchiveWriter, EncoderMethod, Error, Password, writer::LazyFileReader};
+#[cfg(feature = "aes256")]
+use crate::{EncoderMethod, Password};
+use crate::{ArchiveEntry, ArchiveWriter, Error, writer::LazyFileReader};
 
 /// Compresses a source file or directory to a destination writer.
 ///

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -22,7 +22,10 @@ use crc32fast::Hasher;
 pub(crate) use self::lazy_file_reader::LazyFileReader;
 pub(crate) use self::seq_reader::SeqReader;
 pub use self::source_reader::SourceReader;
-use self::{pack_info::PackInfo, unpack_info::UnpackInfo};
+use self::{
+    pack_info::PackInfo,
+    unpack_info::{RawCoderSpec, UnpackInfo},
+};
 use crate::{
     ArchiveEntry, AutoFinish, AutoFinisher, ByteWriter, Error,
     archive::*,
@@ -215,6 +218,84 @@ impl<W: Write + Seek> ArchiveWriter<W> {
         entry.size = 0;
         entry.compressed_size = 0;
         entry.has_crc = false;
+        self.files.push(entry);
+        Ok(self.files.last().unwrap())
+    }
+
+    /// Non-solid pack-stream copy: write already-compressed pack bytes and folder
+    /// metadata without re-encoding.
+    ///
+    /// `coders` is the ordered folder coder chain (same order as source block coders).
+    /// `coder_unpack_sizes` is the folder `CodersUnpackSize` vector (one size per coder
+    /// output stream; for a single LZMA2 folder this is `[uncompressed_size]`).
+    ///
+    /// `entry.size` / `entry.crc` / `entry.has_crc` must describe the uncompressed data.
+    /// Pack CRC is computed while copying.
+    pub fn push_packed_entry<R: Read>(
+        &mut self,
+        mut entry: ArchiveEntry,
+        mut pack_reader: R,
+        coders: &[(EncoderMethod, &[u8])],
+        coder_unpack_sizes: Vec<u64>,
+    ) -> Result<&ArchiveEntry> {
+        if entry.is_directory || !entry.has_stream {
+            return Err(Error::other(
+                "push_packed_entry requires a non-directory streamed entry",
+            ));
+        }
+        if coders.is_empty() {
+            return Err(Error::other("push_packed_entry requires at least one coder"));
+        }
+        if coder_unpack_sizes.len() != coders.len() {
+            return Err(Error::other(
+                "push_packed_entry: coder_unpack_sizes length must match coders",
+            ));
+        }
+
+        let mut compressed_len = 0usize;
+        let mut compressed = CompressWrapWriter::new(&mut self.output, &mut compressed_len);
+        let mut buf = [0u8; 64 * 1024];
+        loop {
+            match pack_reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    compressed.write_all(&buf[..n]).map_err(|e| {
+                        Error::io_msg(e, format!("Copy packed entry:{}", entry.name()))
+                    })?;
+                }
+                Err(e) => {
+                    return Err(Error::io_msg(
+                        e,
+                        format!("Copy packed entry:{}", entry.name()),
+                    ));
+                }
+            }
+        }
+        compressed
+            .flush()
+            .map_err(|e| Error::io_msg(e, format!("Copy packed entry:{}", entry.name())))?;
+        let compressed_crc = compressed.crc_value();
+
+        entry.has_stream = true;
+        entry.has_crc = true;
+        entry.compressed_crc = compressed_crc as u64;
+        entry.compressed_size = compressed_len as u64;
+
+        self.pack_info
+            .add_stream(compressed_len as u64, compressed_crc);
+
+        let raw_coders = coders
+            .iter()
+            .map(|(method, props)| RawCoderSpec {
+                method_id: method.id().to_vec(),
+                properties: props.to_vec(),
+            })
+            .collect();
+
+        // CRC written into substreams; entry.crc is the uncompressed CRC.
+        self.unpack_info
+            .add_raw(raw_coders, coder_unpack_sizes, entry.crc as u32);
+
         self.files.push(entry);
         Ok(self.files.last().unwrap())
     }

--- a/src/writer/unpack_info.rs
+++ b/src/writer/unpack_info.rs
@@ -2,6 +2,14 @@ use std::{io::Write, sync::Arc};
 
 use super::*;
 use crate::EncoderConfiguration;
+
+/// Raw method-id + property bytes for re-emitting a folder without re-encoding.
+#[derive(Debug, Clone)]
+pub(crate) struct RawCoderSpec {
+    pub(crate) method_id: Vec<u8>,
+    pub(crate) properties: Vec<u8>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct UnpackInfo {
     pub(crate) blocks: Vec<BlockInfo>,
@@ -16,6 +24,24 @@ impl UnpackInfo {
     ) {
         self.blocks.push(BlockInfo {
             methods,
+            raw_coders: None,
+            sizes,
+            crc,
+            num_sub_unpack_streams: 1,
+            ..Default::default()
+        })
+    }
+
+    /// Add a folder described by raw coder ids/properties (pack-stream copy path).
+    pub(crate) fn add_raw(
+        &mut self,
+        raw_coders: Vec<RawCoderSpec>,
+        sizes: Vec<u64>,
+        crc: u32,
+    ) {
+        self.blocks.push(BlockInfo {
+            methods: Arc::new(Vec::new()),
+            raw_coders: Some(raw_coders),
             sizes,
             crc,
             num_sub_unpack_streams: 1,
@@ -34,6 +60,7 @@ impl UnpackInfo {
     ) {
         self.blocks.push(BlockInfo {
             methods,
+            raw_coders: None,
             sizes,
             crc,
             num_sub_unpack_streams,
@@ -131,6 +158,9 @@ impl UnpackInfo {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct BlockInfo {
     pub(crate) methods: Arc<Vec<EncoderConfiguration>>,
+    /// When set, folder coders are written from raw method-id/properties instead of
+    /// recomputing properties from [`EncoderConfiguration`].
+    pub(crate) raw_coders: Option<Vec<RawCoderSpec>>,
     pub(crate) sizes: Vec<u64>,
     pub(crate) crc: u32,
     pub(crate) num_sub_unpack_streams: u64,
@@ -145,16 +175,44 @@ impl BlockInfo {
         cache: &mut Vec<u8>,
     ) -> std::io::Result<()> {
         cache.clear();
-        let mut num_coders = 0;
-        for mc in self.methods.iter() {
-            num_coders += 1;
-            self.write_single_codec(mc, cache)?;
+        let num_coders = if let Some(raw) = self.raw_coders.as_ref() {
+            for coder in raw {
+                Self::write_raw_codec(coder, cache)?;
+            }
+            raw.len()
+        } else {
+            for mc in self.methods.iter() {
+                self.write_single_codec(mc, cache)?;
+            }
+            self.methods.len()
+        };
+        if num_coders == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "block has no coders",
+            ));
         }
         write_u64(header, num_coders as u64)?;
         header.write_all(cache)?;
         for i in 0..num_coders - 1 {
             write_u64(header, i as u64 + 1)?;
             write_u64(header, i as u64)?;
+        }
+        Ok(())
+    }
+
+    fn write_raw_codec(coder: &RawCoderSpec, out: &mut Vec<u8>) -> std::io::Result<()> {
+        let id = &coder.method_id;
+        let props = &coder.properties;
+        let mut codec_flags = id.len() as u8;
+        if !props.is_empty() {
+            codec_flags |= 0x20;
+        }
+        out.write_u8(codec_flags)?;
+        out.write_all(id)?;
+        if !props.is_empty() {
+            out.write_u8(props.len() as u8)?;
+            out.write_all(props)?;
         }
         Ok(())
     }

--- a/tests/packed_entry_tests.rs
+++ b/tests/packed_entry_tests.rs
@@ -1,0 +1,205 @@
+//! Tests for [`ArchiveWriter::push_packed_entry`] — re-emit already-compressed
+//! non-solid pack streams without re-encoding (archive update / pack-copy).
+
+#[cfg(feature = "compress")]
+use std::io::{Cursor, Read, Seek, SeekFrom};
+
+#[cfg(feature = "compress")]
+use sevenz_rust2::{
+    ArchiveEntry, ArchiveReader, ArchiveWriter, EncoderMethod, Password, SIGNATURE_HEADER_SIZE,
+};
+
+#[cfg(feature = "compress")]
+fn write_three_file_archive() -> Vec<u8> {
+    let mut out = Cursor::new(Vec::new());
+    let mut writer = ArchiveWriter::new(&mut out).expect("writer");
+    for (name, data) in [
+        ("a.txt", b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa payload-a".as_slice()),
+        ("b.txt", b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb payload-b".as_slice()),
+        ("c.txt", b"cccccccccccccccccccccccccccccccc payload-c".as_slice()),
+    ] {
+        let entry = ArchiveEntry::new_file(name);
+        writer
+            .push_archive_entry(entry, Some(Cursor::new(data.to_vec())))
+            .expect("push entry");
+    }
+    writer.finish().expect("finish");
+    out.into_inner()
+}
+
+/// Delete the middle member by pack-copying the other two streams only.
+#[cfg(feature = "compress")]
+#[test]
+fn push_packed_entry_copy_two_of_three_after_delete() {
+    let source_bytes = write_three_file_archive();
+
+    let reader = ArchiveReader::new(Cursor::new(source_bytes.clone()), Password::empty())
+        .expect("open source");
+    let archive = reader.archive().clone();
+    drop(reader);
+
+    assert!(!archive.is_solid, "test fixture must be non-solid");
+    assert_eq!(archive.files.iter().filter(|f| f.has_stream).count(), 3);
+
+    let pack_base = SIGNATURE_HEADER_SIZE + archive.pack_pos();
+    let pack_sizes = archive.pack_sizes();
+    let stream_map = &archive.stream_map;
+    let pack_offsets = stream_map.pack_stream_offsets();
+    let block_first = stream_map.block_first_pack_stream_index();
+
+    let mut dest = Cursor::new(Vec::new());
+    {
+        let mut writer = ArchiveWriter::new(&mut dest).expect("dest writer");
+
+        for (file_index, file) in archive.files.iter().enumerate() {
+            if !file.has_stream || file.is_directory {
+                continue;
+            }
+            // Drop middle file "b.txt".
+            if file.name() == "b.txt" {
+                continue;
+            }
+
+            let block_index = stream_map.file_block_index[file_index].expect("block index");
+            let block = &archive.blocks[block_index];
+            assert_eq!(block.num_unpack_sub_streams(), 1);
+            assert_eq!(block.packed_streams_count(), 1);
+            assert_eq!(block.coders.len(), 1);
+
+            let pack_stream_index = block_first[block_index];
+            let pack_size = pack_sizes[pack_stream_index];
+            let abs = pack_base + pack_offsets[pack_stream_index];
+
+            let mut pack_cursor = Cursor::new(source_bytes.clone());
+            pack_cursor.seek(SeekFrom::Start(abs)).expect("seek pack");
+            let mut pack_slice = pack_cursor.take(pack_size);
+
+            let coder = &block.coders[0];
+            let method =
+                EncoderMethod::by_id(coder.encoder_method_id()).expect("known encoder method");
+            let props = coder.properties().to_vec();
+            let unpack_sizes = block.unpack_sizes().to_vec();
+
+            let entry = file.clone();
+            // Keep original name/size/crc; only rewrite pack region.
+            writer
+                .push_packed_entry(
+                    entry,
+                    &mut pack_slice,
+                    &[(method, props.as_slice())],
+                    unpack_sizes,
+                )
+                .expect("push packed");
+        }
+
+        writer.finish().expect("finish dest");
+    }
+
+    let out_bytes = dest.into_inner();
+    let mut out_reader =
+        ArchiveReader::new(Cursor::new(out_bytes), Password::empty()).expect("open result");
+    assert!(!out_reader.archive().is_solid);
+
+    let names: Vec<_> = out_reader
+        .archive()
+        .files
+        .iter()
+        .filter(|f| f.has_stream)
+        .map(|f| f.name().to_string())
+        .collect();
+    assert_eq!(names, vec!["a.txt".to_string(), "c.txt".to_string()]);
+
+    let mut extracted = std::collections::HashMap::new();
+    out_reader
+        .for_each_entries(|entry, reader| {
+            if entry.has_stream && !entry.is_directory {
+                let mut buf = Vec::new();
+                reader.read_to_end(&mut buf)?;
+                extracted.insert(entry.name().to_string(), buf);
+            }
+            Ok(true)
+        })
+        .expect("extract");
+
+    assert_eq!(
+        extracted.get("a.txt").map(|b| b.as_slice()),
+        Some(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa payload-a".as_slice())
+    );
+    assert_eq!(
+        extracted.get("c.txt").map(|b| b.as_slice()),
+        Some(b"cccccccccccccccccccccccccccccccc payload-c".as_slice())
+    );
+    assert!(!extracted.contains_key("b.txt"));
+}
+
+/// Rename via pack-copy: same pack bytes, different entry name.
+#[cfg(feature = "compress")]
+#[test]
+fn push_packed_entry_rename_keeps_payload() {
+    let source_bytes = write_three_file_archive();
+    let reader = ArchiveReader::new(Cursor::new(source_bytes.clone()), Password::empty())
+        .expect("open source");
+    let archive = reader.archive().clone();
+    drop(reader);
+
+    let pack_base = SIGNATURE_HEADER_SIZE + archive.pack_pos();
+    let pack_sizes = archive.pack_sizes();
+    let stream_map = &archive.stream_map;
+    let pack_offsets = stream_map.pack_stream_offsets();
+    let block_first = stream_map.block_first_pack_stream_index();
+
+    let mut dest = Cursor::new(Vec::new());
+    {
+        let mut writer = ArchiveWriter::new(&mut dest).expect("dest writer");
+        for (file_index, file) in archive.files.iter().enumerate() {
+            if !file.has_stream || file.is_directory {
+                continue;
+            }
+            let block_index = stream_map.file_block_index[file_index].expect("block");
+            let block = &archive.blocks[block_index];
+            let pack_stream_index = block_first[block_index];
+            let pack_size = pack_sizes[pack_stream_index];
+            let abs = pack_base + pack_offsets[pack_stream_index];
+
+            let mut pack_cursor = Cursor::new(source_bytes.clone());
+            pack_cursor.seek(SeekFrom::Start(abs)).unwrap();
+            let mut pack_slice = pack_cursor.take(pack_size);
+
+            let coder = &block.coders[0];
+            let method = EncoderMethod::by_id(coder.encoder_method_id()).unwrap();
+            let props = coder.properties().to_vec();
+
+            let mut entry = file.clone();
+            if entry.name() == "a.txt" {
+                entry.name = "a-renamed.txt".into();
+            }
+            writer
+                .push_packed_entry(
+                    entry,
+                    &mut pack_slice,
+                    &[(method, props.as_slice())],
+                    block.unpack_sizes().to_vec(),
+                )
+                .unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    let mut out_reader =
+        ArchiveReader::new(Cursor::new(dest.into_inner()), Password::empty()).unwrap();
+    let mut found = None;
+    out_reader
+        .for_each_entries(|entry, reader| {
+            if entry.name() == "a-renamed.txt" {
+                let mut buf = Vec::new();
+                reader.read_to_end(&mut buf)?;
+                found = Some(buf);
+            }
+            Ok(true)
+        })
+        .unwrap();
+    assert_eq!(
+        found.as_deref(),
+        Some(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa payload-a".as_slice())
+    );
+}


### PR DESCRIPTION
## Summary

Adds `ArchiveWriter::push_packed_entry` so clients can re-emit **already-compressed** non-solid pack streams without re-encoding. This is the building block for efficient archive **update** paths (delete/rename/add kept members by byte-copying their pack data and rewriting folder metadata).

Also exposes small public accessors on `Block` / `Coder` that update clients need to inspect folder structure and coder properties:

- `Block::num_unpack_sub_streams`, `packed_streams_count`, `unpack_sizes`
- `Coder::properties`, `num_in_streams`, `num_out_streams`

Internally, `UnpackInfo` gains a raw-coder write path so folder headers can be rebuilt from method-id + property bytes instead of recomputing properties from `EncoderConfiguration`.

Minor fix: gate `EncoderMethod` / `Password` imports in `util/compress.rs` behind `aes256` (avoids unused-import warnings when aes is disabled).

## Motivation

Tools that edit 7z archives (e.g. [Archi](https://github.com/IkEr0228/Archi)) currently must fully decompress and re-LZMA every kept member on each edit. For Max/Normal compression that is often the dominant cost. Non-solid archives map 1 file → 1 pack stream, so pack-stream copy is correct and much faster.

## API sketch

```rust
writer.push_packed_entry(
    entry,                 // name/size/crc for the member
    pack_reader,           // raw compressed pack bytes
    &[(method, props)],    // folder coder chain (usually single LZMA2)
    unpack_sizes,          // folder CodersUnpackSize
)?;
```

## Testing

```
cargo test --features compress --test packed_entry_tests
```

- `push_packed_entry_copy_two_of_three_after_delete` — drop one of three files by pack-copying the other two; extract equals original payloads
- `push_packed_entry_rename_keeps_payload` — rename via pack-copy without re-encode

## Notes / non-goals

- Solid archives (multi unpack sub-streams per block) are **out of scope** for this API; clients should detect `num_unpack_sub_streams > 1` and fall back to decode/re-encode.
- No change to default create/solid compression behavior.
- Semver: additive public API → compatible with a minor release.

## Checklist

- [x] Tests for the new API
- [x] CHANGELOG Unreleased entry
- [x] Docs on public items