### PR TITLE
fix: stop `for_each_entries` at the first `Ok(false)`

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1629,6 +1629,9 @@ impl<R: Read + Seek> ArchiveReader<R> {
 
     /// Takes a closure to decode each files in the archive.
     ///
+    /// Returning `Ok(false)` from the closure stops the iteration: no further block is
+    /// decoded and no further entry is visited.
+    ///
     /// Attention about solid archive:
     /// When decoding a solid archive, the data to be decompressed depends on the data in front of it,
     /// you cannot simply skip the previous data and only decompress the data in the back.
@@ -1645,7 +1648,13 @@ impl<R: Read + Seek> ArchiveReader<R> {
                 &self.password,
                 &mut self.source,
             );
-            forder_dec.for_each_entries(&mut each)?;
+            // Stop as soon as the closure asks to. `BlockDecoder::for_each_entries`
+            // already reports this, and the empty-file loop below already honors it;
+            // without this the outer loop kept building a decode stack and seeking for
+            // every remaining block after the caller was done.
+            if !forder_dec.for_each_entries(&mut each)? {
+                return Ok(());
+            }
         }
         // decode empty files
         for file_index in 0..self.archive.files.len() {

--- a/tests/decompression_tests.rs
+++ b/tests/decompression_tests.rs
@@ -7,7 +7,7 @@ use std::{
 
 #[cfg(feature = "util")]
 use sevenz_rust2::decompress_file;
-use sevenz_rust2::{Archive, ArchiveReader, BlockDecoder, Password};
+use sevenz_rust2::{Archive, ArchiveEntry, ArchiveReader, BlockDecoder, Password};
 #[cfg(feature = "util")]
 use tempfile::tempdir;
 
@@ -249,6 +249,35 @@ fn test_bcj2() {
         })
         .unwrap();
     }
+}
+
+/// Returning `Ok(false)` from the closure must stop the WHOLE iteration, not just the
+/// current block. `ArchiveReader::for_each_entries` used to discard the result of
+/// `BlockDecoder::for_each_entries`, so after the caller asked to stop it still built a
+/// decode stack and seeked for every remaining block. That is wasted work on any normal
+/// early exit (e.g. "read the first entry and stop"), and an attacker-controlled amount
+/// of it on a crafted archive that declares a large number of blocks.
+#[test]
+fn for_each_entries_stops_on_first_false() {
+    let file = File::open("tests/resources/non_solid.7z").unwrap();
+    let mut reader = ArchiveReader::new(file, Password::empty()).unwrap();
+    assert!(
+        reader.archive().blocks.len() > 1,
+        "fixture needs several blocks for this test to be meaningful"
+    );
+
+    let mut visited = 0usize;
+    reader
+        .for_each_entries(|_entry: &ArchiveEntry, _reader: &mut dyn std::io::Read| {
+            visited += 1;
+            Ok(false)
+        })
+        .unwrap();
+
+    assert_eq!(
+        visited, 1,
+        "iteration must stop at the first `Ok(false)`, not continue into the next block"
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Problem

`ArchiveReader::for_each_entries` discards the `bool` returned by `BlockDecoder::for_each_entries`:

```rust
forder_dec.for_each_entries(&mut each)?;
```

So a closure returning `Ok(false)` only stops the **current block**. The outer loop keeps going, building a fresh decode stack and seeking the source for every remaining block before consulting the closure again.

This is inconsistent with three things that already treat the `bool` as "continue?":

- the documented closure contract,
- `BlockDecoder::for_each_entries`, which already returns it, and
- the empty-file loop directly below in the same function, which already does `if !each(...)? { return Ok(()); }`.

### Why it matters

- **Normal use:** any early exit ("read the first entry and stop", "find one entry and bail") silently pays for a decode-stack build + seek per remaining block.
- **Untrusted archives:** the amount of that work is influenced by the archive header, since a crafted `.7z` can declare a large number of blocks. Each one costs a seek and a decode-stack construction even though the caller already asked to stop. It is bounded (block/substream counts are limited by the header length via `bounded_count`, and #119 validates block file spans), so this is wasted work rather than a memory-safety issue, but it is work the caller explicitly opted out of.

### Fix

Honor the stop signal in the block loop, matching the empty-file loop below it.

### Test

Adds `for_each_entries_stops_on_first_false` over the existing multi-block `tests/resources/non_solid.7z` fixture: it asserts the closure is invoked exactly once when it immediately returns `Ok(false)`.

Verified the test has teeth: with the fix reverted it counts **3** invocations (one per block) and fails; with the fix it counts **1**.

### Verification

- `cargo test --all-features` - all 85 tests pass, no regressions.
- `cargo clippy --all-features --all-targets -- -D warnings` - clean.
- `cargo fmt --check` - clean.

Behavior is unchanged for any closure that always returns `Ok(true)` (the crate's own `util/decompress.rs` and `util/wasm.rs` callers), so this is not a breaking change in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
