### PR TITLE
Expose a coder's properties

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -92,6 +92,13 @@ impl Coder {
         &self.encoder_method_id[0..self.id_size]
     }
 
+    /// Returns this coder's properties: the method-specific parameters stored alongside the method
+    /// ID, empty for a method that takes none. How to interpret them depends on
+    /// [`encoder_method_id`](Self::encoder_method_id).
+    pub fn properties(&self) -> &[u8] {
+        &self.properties
+    }
+
     pub(crate) fn decompression_method_id_mut(&mut self) -> &mut [u8] {
         &mut self.encoder_method_id[0..self.id_size]
     }


### PR DESCRIPTION
Adds `Coder::properties()`, a read-only accessor for data the type already holds.

### Why

`encoder_method_id()` tells a caller which method a block uses, but not how it was configured, and the `properties` that answer that are `pub(crate)`. A caller deciding what a block will cost before decoding it has to guess.

The LZMA2 dictionary size is the case that costs real memory. It bounds what a decoder needs, and without it the only safe substitute is the unpacked size of what is being decoded, which is the *whole* thread block when a multi-threaded encoder wrote the archive, roughly four times the real dictionary.

### Measured

A 2.3 GB `.7z` written by 7-Zip's default encoder, extracted with one decoder per thread-block boundary, 24 threads:

| dictionary window from | peak RSS | CPU |
|---|---|---|
| unpacked size (the guess) | 2809 MB | 29.6 s |
| `properties()` (the truth) | **867 MB** | **25.0 s** |

3.2x less memory, and 15% less CPU from the allocation that no longer happens. Median of three rounds with the order rotated, output verified byte-for-byte against the corpus manifest. Same machine, same archive, one line apart.

### Shape

Purely additive: 15 lines in `src/block.rs`, mirroring `encoder_method_id` directly above it. Nothing changed or removed.

The doc comment says how to read the bytes for the common methods, since that is the part a caller otherwise has to go and look up.

### Context

Written for [Cram](https://github.com/lukr54/cram), a 7z/zip/tar archive manager. It ships against a published fork (`sevenz-rust2-cram`) only because a crate on crates.io cannot depend on a git dependency or a `[patch.crates-io]` entry; the fork retires if this and #132 land.

If you would rather expose the parsed dictionary size than the raw bytes, or name it differently, I am happy either way. The raw accessor just seemed the smaller commitment for you to keep.
