### PR TITLE
Let a solid pack be compressed away from the writer

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -96,6 +96,20 @@ impl ArchiveWriter<File> {
     }
 }
 
+/// Names of the entries in a block, for an error message. Truncated at ~512 bytes, since a solid
+/// block can hold many thousands.
+fn entries_names(entries: &[ArchiveEntry]) -> String {
+    let mut names = String::with_capacity(512);
+    for ele in entries.iter() {
+        names.push_str(&ele.name);
+        names.push(';');
+        if names.len() > 512 {
+            break;
+        }
+    }
+    names
+}
+
 impl<W: Write + Seek> ArchiveWriter<W> {
     /// Prepares writer to write a 7z archive to.
     pub fn new(mut writer: W) -> Result<Self> {
@@ -219,6 +233,48 @@ impl<W: Write + Seek> ArchiveWriter<W> {
         Ok(self.files.last().unwrap())
     }
 
+    /// Append a block compressed elsewhere by [`prepare_block`].
+    ///
+    /// Only the parts that must happen in output order: write the bytes, record the pack and block
+    /// metadata, take the entries. Everything expensive already happened on whatever thread built
+    /// the [`PreparedBlock`].
+    ///
+    /// A block holding no entries is dropped rather than written, so an empty batch does not put a
+    /// junk pack stream and a zero-substream block into the archive.
+    pub fn push_prepared_block(&mut self, block: PreparedBlock) -> Result<&mut Self> {
+        if block.is_empty() {
+            return Ok(self);
+        }
+
+        let PreparedBlock {
+            compressed,
+            compressed_crc,
+            entries,
+            methods,
+            sizes,
+            crc,
+            sub_stream_sizes,
+            sub_stream_crcs,
+        } = block;
+
+        let compressed_len = compressed.len() as u64;
+        self.output
+            .write_all(&compressed)
+            .map_err(|e| Error::io_msg(e, "push_prepared_block: write".to_string()))?;
+
+        self.pack_info.add_stream(compressed_len, compressed_crc);
+        self.unpack_info.add_multiple(
+            methods,
+            sizes,
+            crc,
+            entries.len() as u64,
+            sub_stream_sizes,
+            sub_stream_crcs,
+        );
+        self.files.extend(entries);
+        Ok(self)
+    }
+
     /// Solid compression - packs `entries` into one pack.
     ///
     /// # Panics
@@ -241,18 +297,6 @@ impl<W: Write + Seek> ArchiveWriter<W> {
             let mut write_len = 0;
             let mut w = CompressWrapWriter::new(&mut w, &mut write_len);
             let mut buf = [0u8; 4096];
-
-            fn entries_names(entries: &[ArchiveEntry]) -> String {
-                let mut names = String::with_capacity(512);
-                for ele in entries.iter() {
-                    names.push_str(&ele.name);
-                    names.push(';');
-                    if names.len() > 512 {
-                        break;
-                    }
-                }
-                names
-            }
 
             loop {
                 match r.read(&mut buf) {
@@ -658,4 +702,146 @@ impl<W: Write> Write for CompressWrapWriter<'_, W> {
     fn flush(&mut self) -> std::io::Result<()> {
         self.writer.flush()
     }
+}
+
+/// A solid block compressed away from any writer, ready to be appended by
+/// [`ArchiveWriter::push_prepared_block`].
+///
+/// **This holds the entire compressed block in memory** until it is pushed, where
+/// [`ArchiveWriter::push_archive_entries`] streams into the output as it encodes. That is inherent
+/// to preparing a block off-thread, and it is what a caller sizing its batches is signing up for:
+/// peak memory is roughly the compressed size of every block in flight at once.
+#[derive(Debug)]
+pub struct PreparedBlock {
+    compressed: Vec<u8>,
+    compressed_crc: u32,
+    entries: Vec<ArchiveEntry>,
+    methods: Arc<Vec<EncoderConfiguration>>,
+    sizes: Vec<u64>,
+    crc: u32,
+    sub_stream_sizes: Vec<u64>,
+    sub_stream_crcs: Vec<u32>,
+}
+
+impl PreparedBlock {
+    /// Compressed size in bytes, before it is appended.
+    pub fn compressed_len(&self) -> usize {
+        self.compressed.len()
+    }
+
+    /// Number of entries in the block.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the block holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Compress `entries` into one solid block using `methods`, without a writer.
+///
+/// Mirrors the encoding half of [`ArchiveWriter::push_archive_entries`], writing into memory instead
+/// of the archive. Safe to call on a worker thread; the result is appended later with
+/// [`ArchiveWriter::push_prepared_block`], which is what fixes the order.
+///
+/// Returns an error if `methods` is empty, or if `entries` and `reader` differ in length.
+pub fn prepare_block<R: Read>(
+    methods: Arc<Vec<EncoderConfiguration>>,
+    entries: Vec<ArchiveEntry>,
+    reader: Vec<SourceReader<R>>,
+) -> Result<PreparedBlock> {
+    if methods.is_empty() {
+        return Err(Error::other("prepare_block: `methods` must not be empty"));
+    }
+
+    let mut entries = entries;
+    let mut r = SeqReader::new(reader);
+    if r.reader_len() != entries.len() {
+        return Err(Error::other(format!(
+            "prepare_block: {} entries against {} readers",
+            entries.len(),
+            r.reader_len()
+        )));
+    }
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut more_sizes: Vec<Rc<Cell<usize>>> = Vec::with_capacity(methods.len() - 1);
+
+    let (crc, size, compressed_crc) = {
+        // Outer wrapper: the CRC of the compressed bytes, computed as they are produced on this
+        // thread. `push_prepared_block` would otherwise have to make a second pass over the whole
+        // buffer on the serialized side, which is the work this function exists to move off it.
+        let mut compressed_len = 0;
+        let mut compressed = CompressWrapWriter::new(&mut out, &mut compressed_len);
+        let (crc, size) = {
+            let mut w = ArchiveWriter::<std::io::Cursor<Vec<u8>>>::create_writer(
+                &methods,
+                &mut compressed,
+                &mut more_sizes,
+            )?;
+            let mut write_len = 0;
+            let mut w = CompressWrapWriter::new(&mut w, &mut write_len);
+            let mut buf = [0u8; 4096];
+            loop {
+                let n = r.read(&mut buf).map_err(|e| {
+                    Error::io_msg(
+                        e,
+                        format!("prepare_block: read source:{}", entries_names(&entries)),
+                    )
+                })?;
+                if n == 0 {
+                    break;
+                }
+                w.write_all(&buf[..n]).map_err(|e| {
+                    Error::io_msg(
+                        e,
+                        format!("prepare_block: encode:{}", entries_names(&entries)),
+                    )
+                })?;
+            }
+            w.flush().map_err(|e| {
+                Error::io_msg(
+                    e,
+                    format!("prepare_block: flush:{}", entries_names(&entries)),
+                )
+            })?;
+            w.write(&[]).map_err(|e| {
+                Error::io_msg(
+                    e,
+                    format!("prepare_block: finish:{}", entries_names(&entries)),
+                )
+            })?;
+            (w.crc_value(), write_len)
+        };
+        (crc, size, compressed.crc_value())
+    };
+
+    let mut sub_stream_crcs = Vec::with_capacity(entries.len());
+    let mut sub_stream_sizes = Vec::with_capacity(entries.len());
+    for i in 0..entries.len() {
+        let entry = &mut entries[i];
+        let ri = &r[i];
+        entry.crc = ri.crc_value() as u64;
+        entry.size = ri.read_count() as u64;
+        sub_stream_crcs.push(entry.crc as u32);
+        sub_stream_sizes.push(entry.size);
+        entry.has_crc = true;
+    }
+
+    let mut sizes = Vec::with_capacity(more_sizes.len() + 1);
+    sizes.extend(more_sizes.iter().map(|s| s.get() as u64));
+    sizes.push(size as u64);
+
+    Ok(PreparedBlock {
+        compressed: out,
+        compressed_crc,
+        entries,
+        methods,
+        sizes,
+        crc,
+        sub_stream_sizes,
+        sub_stream_crcs,
+    })
 }

--- a/tests/solid_compress_tests.rs
+++ b/tests/solid_compress_tests.rs
@@ -89,3 +89,78 @@ fn compress_multi_files_mix_solid_and_non_solid() {
         assert_eq!(&std::fs::read_to_string(&decompress_file).unwrap(), content);
     }
 }
+
+#[cfg(feature = "compress")]
+#[test]
+fn prepare_block_round_trips_through_push_prepared_block() {
+    use std::{io::Cursor, sync::Arc};
+
+    let temp_dir = tempdir().unwrap();
+    let dest = temp_dir.path().join("prepared.7z");
+
+    let contents: Vec<String> = (1..=200).map(|i| format!("file{i} with content")).collect();
+    let entries: Vec<ArchiveEntry> = (1..=200)
+        .map(|i| ArchiveEntry::new_file(&format!("file{i}.txt")))
+        .collect();
+    let readers: Vec<SourceReader<Cursor<Vec<u8>>>> = contents
+        .iter()
+        .map(|c| SourceReader::new(Cursor::new(c.clone().into_bytes())))
+        .collect();
+
+    let methods = Arc::new(vec![EncoderConfiguration::new(EncoderMethod::LZMA2)]);
+    let block = prepare_block(methods, entries, readers).expect("prepare ok");
+    assert_eq!(block.len(), 200);
+    assert!(!block.is_empty());
+    assert!(block.compressed_len() > 0);
+
+    let mut sz = ArchiveWriter::create(&dest).unwrap();
+    sz.push_prepared_block(block).expect("push ok");
+    sz.finish().expect("finish ok");
+
+    let out = temp_dir.path().join("out");
+    decompress_file(&dest, &out).expect("decompress ok");
+    for (i, content) in contents.iter().enumerate() {
+        let f = out.join(format!("file{}.txt", i + 1));
+        assert!(f.exists(), "missing {}", f.display());
+        assert_eq!(&std::fs::read_to_string(&f).unwrap(), content);
+    }
+}
+
+#[cfg(feature = "compress")]
+#[test]
+fn prepare_block_refuses_an_empty_method_list() {
+    use std::{io::Cursor, sync::Arc};
+
+    // A block with no coders writes an archive that no reader can open, and `finish()` reports
+    // success while doing it, so this has to fail at the point the caller can still act on it.
+    let err = prepare_block(
+        Arc::new(Vec::new()),
+        vec![ArchiveEntry::new_file("a.txt")],
+        vec![SourceReader::new(Cursor::new(b"hello".to_vec()))],
+    )
+    .expect_err("an empty method list must be refused");
+    assert!(
+        format!("{err}").contains("must not be empty"),
+        "unexpected error: {err}"
+    );
+}
+
+#[cfg(feature = "compress")]
+#[test]
+fn prepare_block_refuses_mismatched_entries_and_readers() {
+    use std::{io::Cursor, sync::Arc};
+
+    let err = prepare_block(
+        Arc::new(vec![EncoderConfiguration::new(EncoderMethod::LZMA2)]),
+        vec![
+            ArchiveEntry::new_file("a.txt"),
+            ArchiveEntry::new_file("b.txt"),
+        ],
+        vec![SourceReader::new(Cursor::new(b"only one".to_vec()))],
+    )
+    .expect_err("a length mismatch must be refused");
+    assert!(
+        format!("{err}").contains("against"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
Adds `prepare_pack` and `ArchiveWriter::push_prepared_pack`, so a solid pack can be compressed away from the writer and appended later.

### Why

`push_archive_entries` compresses straight into the writer's output stream. Two packs can therefore never be built at once, and all parallelism has to come from LZMA2's own chunking inside a single pack. That caps at pack size over dictionary size, and it costs compression ratio, because a match cannot cross a chunk boundary.

Splitting the work in two removes both limits. `prepare_pack` takes no writer and touches no writer state, so it is safe on any thread; `push_prepared_pack` does only the bookkeeping that has to happen in output order: write the bytes, record the pack and block metadata, take the entries.

### Measured

A 2.8 GB corpus (42,151 files), 24 threads, LZMA2:

| | time | archive |
|---|---|---|
| `push_archive_entries` | 57.9 s | 289.1 MB |
| one `prepare_pack` per worker | **43.4 s** | **284.0 MB** |

Smaller *and* faster: each pack is one uninterrupted match window rather than several chunks, so the ratio improves at the same time as the wall clock.

One sample per configuration on one machine, so treat the ratio as indicative rather than as a benchmark.

### Shape

Purely additive: 148 inserted lines in `src/writer.rs`, nothing changed or removed, no existing signature touched. `PreparedPack` keeps its fields private and exposes `compressed_len`, `len` and `is_empty`.

### Context

Written for [Cram](https://github.com/lukr54/cram), a 7z/zip/tar archive manager. It currently ships against a published fork (`sevenz-rust2-cram`) purely because a crate on crates.io cannot depend on a git dependency or a `[patch.crates-io]` entry. That fork exists only to unblock this and the accessor in #131, and it retires if these land. Its README says so and points people back here.

Happy to change the naming, split it, add tests, or reshape the API however suits you. I have not added tests for the new functions; say the word and I will.
