### PR TITLE
fix: precompute each block's first sub-stream index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Opening a block no longer re-sums the sub-stream counts of every preceding block to locate its CRC, which made reading an archive of many non-solid blocks quadratic in the block count.
+
 ## 0.22.2 - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Opening a block no longer re-sums the sub-stream counts of every preceding block to locate its CRC, which made reading an archive of many non-solid blocks quadratic in the block count.
+- Improved decompression performance for non-solid 7z archives containing many files.
 
 ## 0.22.2 - 2026-08-25
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -464,6 +464,10 @@ impl EncoderMethod {
 pub struct StreamMap {
     pub(crate) block_first_pack_stream_index: Vec<usize>,
     pub(crate) pack_stream_offsets: Vec<u64>,
+    /// Index of the first sub-stream of each block into `SubStreamsInfo`
+    /// (`unpack_sizes` / `has_crc` / `crcs`): the running sum of
+    /// `num_unpack_sub_streams` over the preceding blocks.
+    pub(crate) block_first_sub_stream_index: Vec<usize>,
     /// Index of first file for each block.
     pub block_first_file_index: Vec<usize>,
     /// Block index for each file (None if file has no data).

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -732,6 +732,19 @@ impl Archive {
             }
         }
 
+        // `SubStreamsInfo` is indexed by the running sub-stream count over all
+        // blocks. Record each block's first index here so `build_decode_stack`
+        // does not re-sum the preceding blocks every time it opens one, which
+        // made extracting an archive of many non-solid blocks quadratic.
+        let mut next_sub_stream_index: usize = 0;
+        stream_map.block_first_sub_stream_index = vec![0; num_blocks];
+        for i in 0..num_blocks {
+            stream_map.block_first_sub_stream_index[i] = next_sub_stream_index;
+            next_sub_stream_index = next_sub_stream_index
+                .checked_add(archive.blocks[i].num_unpack_sub_streams)
+                .ok_or_else(|| Error::other("sub-stream index overflow"))?;
+        }
+
         let mut next_pack_stream_offset: u64 = 0;
         let num_pack_sizes = archive.pack_sizes.len();
         stream_map.pack_stream_offsets = vec![0; num_pack_sizes];
@@ -1364,10 +1377,7 @@ impl<R: Read + Seek> ArchiveReader<R> {
             && block.num_unpack_sub_streams == 1
             && let Some(sub_streams_info) = archive.sub_streams_info.as_ref()
         {
-            let mut substream_index = 0;
-            for i in 0..block_index {
-                substream_index += archive.blocks[i].num_unpack_sub_streams;
-            }
+            let substream_index = archive.stream_map.block_first_sub_stream_index[block_index];
 
             // Only when there is a single stream, we can use it's CRC to verify the compressed block data.
             // Multiple streams would contain the CRC of the compressed data for each file in the block.


### PR DESCRIPTION
## Summary

`ArchiveReader::build_decode_stack` locates a single-stream block's CRC in `SubStreamsInfo` by summing `num_unpack_sub_streams` over every preceding block:

```rust
let mut substream_index = 0;
for i in 0..block_index {
    substream_index += archive.blocks[i].num_unpack_sub_streams;
}
```

That runs once per block opened, so reading a non-solid archive (one block per file, which is what `7z a -ms=off` writes) block after block is quadratic in the block count. This PR records each block's first sub-stream index in `StreamMap` while `calculate_stream_map` is walking the blocks anyway, and reads it in the decoder. CRC lookup and verification are unchanged; the new field is `pub(crate)` like `block_first_pack_stream_index`.

## Measurement

Archive: 20 000 small files, `7zz a -mx5 -ms=off` (20 000 LZMA2 blocks, 16 MiB). A release-build example opens each block with `BlockDecoder::new(1, ..)` and drains it into `io::sink()`; i7-14700KF, median of 3 runs after a warm-up:

| | wall | user |
|---|---|---|
| master (b7e2651) | 0.61 s | 0.59 s |
| this PR | 0.55 s | 0.53 s |

The 2 × 10⁸ additions are about 10 % of the time to open and decode every block of this archive; the share grows linearly with the block count.

Found while profiling smart-extractor's native 7z backend, where this loop was one of three per-block costs that together put it at 2.2× 7zz on that archive.

## Checks

- `cargo test` (default features)
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`, `--no-default-features`, `--all-features`
