### PR TITLE
Expose the nice length and dictionary size of LZMA and LZMA2 matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `LzmaOptions::set_nice_len` and `Lzma2Options::set_nice_len` set the nice length of a match
+  (7-Zip's word size), and `LzmaOptions::set_dictionary_size` sets the dictionary size as
+  `Lzma2Options::set_dictionary_size` does.
+- `EncoderConfiguration` can be built from `LzmaOptions` with `into()`, as it can from the other
+  option types.
+
 ### Fixed
 
 - Improved decompression performance for non-solid 7z archives containing many files.

--- a/src/encoder_options.rs
+++ b/src/encoder_options.rs
@@ -28,6 +28,25 @@ impl LzmaOptions {
     pub fn from_level(level: u32) -> Self {
         Self(lzma_rust2::LzmaOptions::with_preset(level))
     }
+
+    /// Sets the dictionary size used when encoding.
+    ///
+    /// Will be clamped between 4096..=4294967280.
+    pub fn set_dictionary_size(&mut self, dict_size: u32) {
+        self.0.dict_size = dict_size.clamp(lzma_rust2::DICT_SIZE_MIN, lzma_rust2::DICT_SIZE_MAX);
+    }
+
+    /// Sets the nice length of a match (7-Zip's "word size"): the encoder stops looking for a
+    /// longer match once it finds one at least this long. Higher values compress slightly better
+    /// and slower.
+    ///
+    /// Will be clamped between 8..=273.
+    pub fn set_nice_len(&mut self, nice_len: u32) {
+        self.0.nice_len = nice_len.clamp(
+            lzma_rust2::LzmaOptions::NICE_LEN_MIN,
+            lzma_rust2::LzmaOptions::NICE_LEN_MAX,
+        );
+    }
 }
 
 #[cfg(feature = "compress")]
@@ -85,6 +104,18 @@ impl Lzma2Options {
     pub fn set_dictionary_size(&mut self, dict_size: u32) {
         self.options.lzma_options.dict_size =
             dict_size.clamp(lzma_rust2::DICT_SIZE_MIN, lzma_rust2::DICT_SIZE_MAX);
+    }
+
+    /// Sets the nice length of a match (7-Zip's "word size"): the encoder stops looking for a
+    /// longer match once it finds one at least this long. Higher values compress slightly better
+    /// and slower.
+    ///
+    /// Will be clamped between 8..=273.
+    pub fn set_nice_len(&mut self, nice_len: u32) {
+        self.options.lzma_options.nice_len = nice_len.clamp(
+            lzma_rust2::LzmaOptions::NICE_LEN_MIN,
+            lzma_rust2::LzmaOptions::NICE_LEN_MAX,
+        );
     }
 }
 
@@ -442,6 +473,13 @@ impl From<AesEncoderOptions> for EncoderConfiguration {
 impl From<DeltaOptions> for EncoderConfiguration {
     fn from(options: DeltaOptions) -> Self {
         Self::new(crate::EncoderMethod::DELTA_FILTER).with_options(EncoderOptions::Delta(options))
+    }
+}
+
+#[cfg(feature = "compress")]
+impl From<LzmaOptions> for EncoderConfiguration {
+    fn from(options: LzmaOptions) -> Self {
+        Self::new(crate::EncoderMethod::LZMA).with_options(EncoderOptions::Lzma(options))
     }
 }
 

--- a/tests/compress_tests.rs
+++ b/tests/compress_tests.rs
@@ -486,3 +486,48 @@ fn compress_path_does_not_emit_root_dir_entry() {
     assert!(names.iter().any(|n| n == "sub"));
     assert!(names.iter().any(|n| n == "sub/file2.txt"));
 }
+
+#[cfg(feature = "compress")]
+#[test]
+fn nice_len_is_clamped_and_round_trips() {
+    use std::io::Cursor;
+
+    use sevenz_rust2::{
+        Archive, ArchiveEntry, ArchiveWriter, BlockDecoder, Password,
+        encoder_options::{Lzma2Options, LzmaOptions},
+    };
+
+    let content = std::fs::read("tests/resources/apache2.txt").unwrap();
+
+    for nice_len in [0, 32, 1000] {
+        let mut lzma2 = Lzma2Options::from_level(6);
+        lzma2.set_nice_len(nice_len);
+        let mut lzma = LzmaOptions::from_level(6);
+        lzma.set_nice_len(nice_len);
+        lzma.set_dictionary_size(1 << 20);
+
+        for options in [lzma2.into(), lzma.into()] {
+            let mut bytes = Vec::new();
+            {
+                let mut writer = ArchiveWriter::new(Cursor::new(&mut bytes)).unwrap();
+                writer.set_content_methods(vec![options]);
+                let entry = ArchiveEntry::new_file("apache2.txt");
+                writer
+                    .push_archive_entry(entry, Some(content.as_slice()))
+                    .unwrap();
+                writer.finish().unwrap();
+            }
+
+            let mut cursor = Cursor::new(bytes.as_slice());
+            let archive = Archive::read(&mut cursor, &Password::empty()).unwrap();
+            let mut decoded = Vec::new();
+            BlockDecoder::new(1, 0, &archive, &Password::empty(), &mut cursor)
+                .for_each_entries(&mut |_, reader| {
+                    reader.read_to_end(&mut decoded)?;
+                    Ok(true)
+                })
+                .unwrap();
+            assert_eq!(decoded, content, "nice_len {nice_len}");
+        }
+    }
+}


### PR DESCRIPTION
7-Zip calls it the word size and offers it next to the dictionary size. The options types only exposed the dictionary, and only for LZMA2, so a caller mapping 7-Zip's knobs onto this crate had no way to set them.

- `LzmaOptions::set_nice_len` and `Lzma2Options::set_nice_len`, clamped to the encoder's bounds the way `set_dictionary_size` is.
- `LzmaOptions::set_dictionary_size`, which `Lzma2Options` already had.
- `impl From<LzmaOptions> for EncoderConfiguration`, which the other option types already had.
- A test that both setters round-trip through the writer and reader at a clamped-low, a normal and a clamped-high nice length.
- A changelog entry under Unreleased.