### PR TITLE
Close a PPMd stream's range coder once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- PPMd streams were written with five extra bytes at the end (the range coder was flushed by
+  `flush` and again by `finish`), which 7-Zip rejects as a data error.
+
 - Improved decompression performance for non-solid 7z archives containing many files.
 
 ## 0.22.2 - 2026-08-25

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -168,8 +168,11 @@ impl<W: Write> Write for Encoder<W> {
             Encoder::Lzma2Mt(w) => w.as_mut().unwrap().flush(),
             #[cfg(feature = "brotli")]
             Encoder::Brotli(w) => w.flush(),
+            // A PPMd flush writes the range coder's five closing bytes, and `finish`
+            // writes them again, which leaves a stream 7-Zip refuses. Only the writer
+            // underneath is flushed here; the range coder closes in `finish`.
             #[cfg(feature = "ppmd")]
-            Encoder::Ppmd(w) => w.as_mut().unwrap().flush(),
+            Encoder::Ppmd(w) => w.as_mut().unwrap().get_mut().flush(),
             #[cfg(feature = "bzip2")]
             Encoder::Bzip2(w) => w.as_mut().unwrap().flush(),
             #[cfg(feature = "deflate")]

--- a/tests/compress_tests.rs
+++ b/tests/compress_tests.rs
@@ -486,3 +486,37 @@ fn compress_path_does_not_emit_root_dir_entry() {
     assert!(names.iter().any(|n| n == "sub"));
     assert!(names.iter().any(|n| n == "sub/file2.txt"));
 }
+
+/// The packed stream 7-Zip 24.03 writes for this input with `-m0=PPMd:o6:mem24`
+/// (order 6, a 16 MiB model): the range coder's bytes and its five closing
+/// bytes, once. A stream flushed twice carries five more, and 7-Zip refuses it.
+#[cfg(all(feature = "compress", feature = "ppmd"))]
+#[test]
+fn ppmd_streams_close_the_range_coder_once_as_seven_zip_does() {
+    use std::io::Cursor;
+
+    use sevenz_rust2::{
+        Archive, ArchiveEntry, ArchiveWriter, Password, encoder_options::PpmdOptions,
+    };
+
+    const SEVEN_ZIP_PACKED: [u8; 13] = [
+        0x00, 0x67, 0xfb, 0x83, 0x7d, 0x70, 0x24, 0x5c, 0x2c, 0xce, 0x87, 0x58, 0x00,
+    ];
+
+    let mut bytes = Vec::new();
+    {
+        let mut writer = ArchiveWriter::new(Cursor::new(&mut bytes)).unwrap();
+        writer.set_content_methods(vec![
+            PpmdOptions::from_order_memory_size(6, 16 << 20).into(),
+        ]);
+        let entry = ArchiveEntry::new_file("tiny.txt");
+        writer
+            .push_archive_entry(entry, Some(&b"hello hello hello\n"[..]))
+            .unwrap();
+        writer.finish().unwrap();
+    }
+
+    let archive = Archive::read(&mut Cursor::new(bytes.as_slice()), &Password::empty()).unwrap();
+    assert_eq!(archive.pack_sizes(), &[SEVEN_ZIP_PACKED.len() as u64]);
+    assert_eq!(&bytes[32..32 + SEVEN_ZIP_PACKED.len()], &SEVEN_ZIP_PACKED);
+}


### PR DESCRIPTION
The writer flushes the coder chain before the empty write that finishes it. For PPMd, `flush` wrote the range coder's five closing bytes and `finish` wrote them again, so every PPMd stream ended in five extra bytes, and 7-Zip refuses the archive with a data error (`7zz t` reports `Data Error` on each PPMd entry). The crate's own decoder reads its output regardless, which is why the round-trip tests did not catch it.

`Encoder::flush` now reaches only the writer underneath the PPMd encoder, and the range coder closes in `finish`. The new test writes a small input with order 6 and a 16 MiB model and pins the packed bytes to what 7-Zip 24.03 writes for the same settings (`-m0=PPMd:o6:mem24`), which also checks that the encoder's output is byte-identical to 7-Zip's.